### PR TITLE
⚡ Bolt: Add `loading="lazy"` to dynamic news images

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+## 2024-04-30 - [Missing Lazy Loading] Learning: [Many images are missing `loading="lazy"` attribute, which causes all images to load synchronously and impacts page load time] Action: [Add `loading="lazy"` to `<img>` tags, except for those in the above-the-fold or hero section]

--- a/js/news.js
+++ b/js/news.js
@@ -165,7 +165,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             <span class="font-semibold text-brand-purple">Read More →</span>
                         </div>
                         <div class="hidden lg:block">
-                            <img src="${article.image}" alt="${altText}" class="w-full h-full object-cover">
+                            <!-- ⚡ Bolt: Add loading="lazy" to defer offscreen images and improve initial page load time -->
+                            <img src="${article.image}" alt="${altText}" class="w-full h-full object-cover" loading="lazy">
                         </div>
                     </div>
                 </a>
@@ -220,7 +221,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             articleCard.innerHTML = `
                 <a href="${article.url}" class="group flex flex-col h-full flex-grow" data-ph-event="news_article_click" data-ph-label="${escapeAttr(article.title)}" data-ph-metadata='{"position":"grid"}'>
-                    <img src="${article.image}" alt="${altText}" class="w-full h-48 object-cover">
+                    <!-- ⚡ Bolt: Add loading="lazy" to defer offscreen images and improve initial page load time -->
+                    <img src="${article.image}" alt="${altText}" class="w-full h-48 object-cover" loading="lazy">
                     <div class="p-6 flex-grow">
                         <div class="flex items-center justify-between mb-2">
                             <p class="text-text-secondary text-sm" title="${dateTooltip}">Last updated: ${formattedDate}</p>


### PR DESCRIPTION
💡 What: Added `loading="lazy"` attribute to dynamically injected `<img>` tags in `js/news.js`.
🎯 Why: Images dynamically loaded into the news grid and the featured article slot were loading synchronously, which can negatively impact initial page load time, especially when these elements appear below the fold.
📊 Impact: Defers loading of off-screen images, improving perceived page load speed and saving initial bandwidth.
🔬 Measurement: Verify via browser network tab that images for news articles lower down on the page are only requested when scrolling near them.

Also added `.jules/bolt.md` to document the performance learning regarding missing lazy loading attributes on this site.

---
*PR created automatically by Jules for task [15119432162596506818](https://jules.google.com/task/15119432162596506818) started by @jaxsnjohnson*