### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,6 @@ Critical UX/accessibility learnings only.
 **Learning:** `type="number"` inputs for currency or decimals (using `step="0.01"`) on mobile devices might show a standard number pad without a decimal point on some OS versions if `inputmode="decimal"` isn't specified.
 **Action:** Always add `inputmode="decimal"` to `<input type="number" step="0.01">` when expecting currency or float values to ensure the correct numeric keypad with a decimal point is displayed for mobile users.
 ## 2024-05-18 - [Use type="search" for search inputs]\n**Learning:** Using `<input type="search">` instead of `<input type="text">` for search fields provides a better mobile experience by triggering the specialized native search keyboard and often adding a native clear button (x) in supported browsers, improving accessibility and usability without additional code.\n**Action:** Always prefer `type="search"` over `type="text"` for dedicated search input fields.
+## 2024-05-18 - [Add `aria-label` to icon-only buttons]
+**Learning:** Icon-only buttons (like image carousel controls or share buttons) that rely solely on `title` attributes or surrounding context are inaccessible to screen readers, leaving users unaware of the button's function.
+**Action:** Always add descriptive `aria-label` attributes to `<button>` or `<a>` elements that do not contain visible text.

--- a/news/2025-08-22-Icecream.html
+++ b/news/2025-08-22-Icecream.html
@@ -239,12 +239,12 @@
                 </div>
 
                 <!-- Navigation Buttons -->
-                <button id="prev-btn" class="absolute top-1/2 left-4 transform -translate-y-1/2 bg-white/50 hover:bg-white rounded-full p-2 transition">
+                <button id="prev-btn" class="absolute top-1/2 left-4 transform -translate-y-1/2 bg-white/50 hover:bg-white rounded-full p-2 transition focus:outline-none focus:ring-2 focus:ring-brand-purple" aria-label="Previous image">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-brand-purple-dark" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
                     </svg>
                 </button>
-                <button id="next-btn" class="absolute top-1/2 right-4 transform -translate-y-1/2 bg-white/50 hover:bg-white rounded-full p-2 transition">
+                <button id="next-btn" class="absolute top-1/2 right-4 transform -translate-y-1/2 bg-white/50 hover:bg-white rounded-full p-2 transition focus:outline-none focus:ring-2 focus:ring-brand-purple" aria-label="Next image">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-brand-purple-dark" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                     </svg>

--- a/test-pages/annotated-page.html
+++ b/test-pages/annotated-page.html
@@ -252,7 +252,7 @@
                 </div>
 
                 <div id="weingarten-rights" class="annotation-card bg-white p-6 rounded-xl border border-brand-purple-dark">
-                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" data-section-id="weingarten-rights">
+                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" aria-label="Copy link to this section" data-section-id="weingarten-rights">
                         <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
                     </button>
                     <h3 class="text-xl font-bold mb-2">Investigatory Interviews (Weingarten Rights)</h3>
@@ -260,7 +260,7 @@
                 </div>
 
                 <div id="grievance-def" class="annotation-card bg-white p-6 rounded-xl border border-brand-purple-dark">
-                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" data-section-id="grievance-def">
+                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" aria-label="Copy link to this section" data-section-id="grievance-def">
                         <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
                     </button>
                     <h3 class="text-xl font-bold mb-2">What is a Grievance?</h3>
@@ -268,7 +268,7 @@
                 </div>
 
                 <div id="grievance-step1" class="annotation-card bg-white p-6 rounded-xl border border-brand-purple-dark">
-                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" data-section-id="grievance-step1">
+                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" aria-label="Copy link to this section" data-section-id="grievance-step1">
                         <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
                     </button>
                     <h3 class="text-xl font-bold mb-2">Step 1: Talk First</h3>
@@ -276,7 +276,7 @@
                 </div>
 
                  <div id="grievance-step2" class="annotation-card bg-white p-6 rounded-xl border border-brand-purple-dark">
-                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" data-section-id="grievance-step2">
+                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" aria-label="Copy link to this section" data-section-id="grievance-step2">
                         <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
                     </button>
                     <h3 class="text-xl font-bold mb-2">Step 2: Make it Formal</h3>
@@ -284,7 +284,7 @@
                 </div>
 
                 <div id="just-cause" class="annotation-card bg-white p-6 rounded-xl border border-brand-purple-dark">
-                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" data-section-id="just-cause">
+                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" aria-label="Copy link to this section" data-section-id="just-cause">
                         <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
                     </button>
                     <h3 class="text-xl font-bold mb-2">Just Cause</h3>
@@ -292,7 +292,7 @@
                 </div>
                 
                 <div id="progressive-discipline" class="annotation-card bg-white p-6 rounded-xl border border-brand-purple-dark">
-                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" data-section-id="progressive-discipline">
+                    <button class="share-btn absolute top-2 right-2 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition" title="Copy link to this section" aria-label="Copy link to this section" data-section-id="progressive-discipline">
                         <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
                     </button>
                     <h3 class="text-xl font-bold mb-2">Progressive Discipline</h3>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only `<button>` elements in the `news/2025-08-22-Icecream.html` carousel and `test-pages/annotated-page.html` share buttons.
🎯 Why: Icon-only buttons without accessible names cannot be understood by screen readers. The `title` attribute alone is insufficient and inaccessible for keyboard and mobile users.
♿ Accessibility: Ensures that screen reader users are aware of the function of the "Previous image", "Next image", and "Copy link to this section" buttons.
📸 Before/After: Visual presentation is unchanged, but the DOM now includes `aria-label`s. Focus styling was also added to carousel buttons.

---
*PR created automatically by Jules for task [16400603992124068292](https://jules.google.com/task/16400603992124068292) started by @jaxsnjohnson*