### PR TITLE
🎨 Palette: Add `aria-pressed` state management to filter toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@ Critical UX/accessibility learnings only.
 ## 2024-05-18 - [Add `aria-label` to icon-only buttons]
 **Learning:** Icon-only buttons (like image carousel controls or share buttons) that rely solely on `title` attributes or surrounding context are inaccessible to screen readers, leaving users unaware of the button's function.
 **Action:** Always add descriptive `aria-label` attributes to `<button>` or `<a>` elements that do not contain visible text.
+## 2024-05-18 - [Add `aria-pressed` to toggle buttons]
+**Learning:** When using buttons as visual toggles (like category filters that turn a distinct color when active), screen reader users are unaware of which filter is currently active if relying solely on CSS classes (e.g., `class="active"`). Using the `aria-pressed` attribute correctly translates the visual state into semantic state for assistive technologies.
+**Action:** Always add `aria-pressed="true"` to active toggle buttons and `aria-pressed="false"` to inactive ones, ensuring JavaScript updates this attribute synchronously with any visual class toggles.

--- a/js/news.js
+++ b/js/news.js
@@ -86,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // "All" button
         const allButton = createTagButton('All');
         allButton.classList.add('active');
+        allButton.setAttribute('aria-pressed', 'true');
         allButton.addEventListener('click', () => {
             activeFilters.activeTag = null;
             setActiveTag(allButton);
@@ -142,13 +143,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const button = document.createElement('button');
         button.className = 'tag-button px-4 py-2 rounded-full text-sm font-semibold transition-colors hover:bg-brand-purple hover:text-white';
         button.textContent = tag;
+        button.setAttribute('aria-pressed', 'false');
         return button;
     }
 
     function setActiveTag(activeButton) {
-        document.querySelectorAll('.tag-button').forEach(btn => btn.classList.remove('active'));
+        document.querySelectorAll('.tag-button').forEach(btn => {
+            btn.classList.remove('active');
+            btn.setAttribute('aria-pressed', 'false');
+        });
         if (activeButton) {
             activeButton.classList.add('active');
+            activeButton.setAttribute('aria-pressed', 'true');
         }
     }
 

--- a/test-pages/search.html
+++ b/test-pages/search.html
@@ -138,10 +138,10 @@
 
             <!-- Filters -->
             <div id="filter-container" class="mt-6 flex justify-center items-center gap-2 flex-wrap">
-                <button class="filter-btn active" data-filter="all">All</button>
-                <button class="filter-btn" data-filter="News">News</button>
-                <button class="filter-btn" data-filter="Event">Events</button>
-                <button class="filter-btn" data-filter="Other">Resources & Other</button>
+                <button class="filter-btn active" data-filter="all" aria-pressed="true">All</button>
+                <button class="filter-btn" data-filter="News" aria-pressed="false">News</button>
+                <button class="filter-btn" data-filter="Event" aria-pressed="false">Events</button>
+                <button class="filter-btn" data-filter="Other" aria-pressed="false">Resources & Other</button>
             </div>
 
             <!-- Results -->
@@ -249,8 +249,13 @@
                 const target = e.target.closest('.filter-btn');
                 if (!target) return;
 
-                filterContainer.querySelector('.active').classList.remove('active');
+                const currentActive = filterContainer.querySelector('.active');
+                if (currentActive) {
+                    currentActive.classList.remove('active');
+                    currentActive.setAttribute('aria-pressed', 'false');
+                }
                 target.classList.add('active');
+                target.setAttribute('aria-pressed', 'true');
                 currentFilter = target.dataset.filter;
                 performSearch();
             });


### PR DESCRIPTION
### 💡 What:
Added `aria-pressed` state management to toggle buttons (`.tag-button` in `js/news.js` and `.filter-btn` in `test-pages/search.html`). The default state is set to `aria-pressed="false"`, while the selected/active buttons have `aria-pressed="true"`.

### 🎯 Why:
Prior to this change, the semantic state of the category filters (whether they were currently selected or not) was communicated exclusively via the `active` CSS class, which changes the button color. Screen reader users were unaware of which filter was currently active. Using the `aria-pressed` attribute correctly translates this visual state into semantic state.

### 📸 Before/After:
No visual changes were made.

### ♿ Accessibility:
Improved accessibility for screen reader users by properly semantically communicating the state of the interactive toggle filter buttons. Recorded this learning to the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [513780169662196963](https://jules.google.com/task/513780169662196963) started by @jaxsnjohnson*