### PR TITLE
⚡ Bolt: Debounce news search rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2024-05-18 - [Date Parsing in Render Loops]
 **Learning:** [Calling `new Date()` and `toLocaleDateString()` inside mapping loops (e.g., `events.map`, `articles.forEach`) causes significant performance overhead and redundant calculations, especially on components that render frequently like the search-filtered news grid.]
 **Action:** [Pre-parse date objects (e.g. `event.parsedDate`) and pre-format localized date strings (e.g. `article.formattedUpdatedAt`) immediately after JSON fetch, then reuse these cached values during DOM updates.]
+
+## 2024-05-18 - [Missing Debounce on Render]
+**Learning:** [Discovered a pattern where search input analytics were debounced, but the actual heavy DOM rendering and array filtering/sorting (`renderArticles`) was left synchronous on every keystroke, causing unnecessary main thread blocking.]
+**Action:** [Always ensure that expensive rendering logic is included within the debounce timeout along with analytics when handling frequent input events.]

--- a/js/news.js
+++ b/js/news.js
@@ -295,8 +295,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (value.trim().length >= 2) {
                 safeCapture('news_search', { term: value.trim() });
             }
+            // ⚡ Bolt: Debounce search input to reduce DOM manipulations and refiltering on every keystroke
+            renderArticles();
         }, 250);
-        renderArticles();
     });
 
     sortSelect.addEventListener('change', (e) => {


### PR DESCRIPTION
💡 What: Moved `renderArticles()` inside the `setTimeout` debounce block in `js/news.js`.
🎯 Why: Prevents the browser from refiltering arrays and re-rendering the DOM synchronously on every keystroke, which blocks the main thread.
📊 Impact: Reduces UI lag and unnecessary DOM manipulations during active typing in the search bar.
🔬 Measurement: Can be verified by observing smoother typing in the search bar on the news page and fewer DOM updates in the dev tools timeline.

---
*PR created automatically by Jules for task [4267442435861426344](https://jules.google.com/task/4267442435861426344) started by @jaxsnjohnson*