### PR TITLE
🎨 Palette: Add empty state for news filters

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@ Critical UX/accessibility learnings only.
 ## 2024-05-18 - [Add `aria-pressed` to toggle buttons]
 **Learning:** When using buttons as visual toggles (like category filters that turn a distinct color when active), screen reader users are unaware of which filter is currently active if relying solely on CSS classes (e.g., `class="active"`). Using the `aria-pressed` attribute correctly translates the visual state into semantic state for assistive technologies.
 **Action:** Always add `aria-pressed="true"` to active toggle buttons and `aria-pressed="false"` to inactive ones, ensuring JavaScript updates this attribute synchronously with any visual class toggles.
+## 2026-05-18 - [Add helpful empty states for filtered lists]
+**Learning:** When users apply search filters that return zero results, a generic "no results" message leaves them stuck. A well-designed empty state with an actionable "Clear Filters" button significantly improves recovery and usability.
+**Action:** Always include a helpful empty state with a clear call-to-action (e.g., a button to reset filters) for any search or filtering mechanism that can return zero results.

--- a/js/news.js
+++ b/js/news.js
@@ -261,7 +261,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function displayArticles(articles) {
         if (articles.length === 0) {
-            articlesGrid.innerHTML = '<p class="text-text-secondary col-span-full text-center">No news articles match your criteria.</p>';
+            articlesGrid.innerHTML = `
+                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                    <h3 class="text-xl font-bold text-brand-purple-dark mb-2">No articles found</h3>
+                    <p class="text-text-secondary mb-6 text-center max-w-md">We couldn't find any news articles matching your search or filter criteria. Try adjusting your search term or clearing the filters.</p>
+                    <button id="reset-filters-btn" class="btn btn-outline" aria-label="Clear all search filters and text">Clear Search & Filters</button>
+                </div>
+            `;
+
+            document.getElementById('reset-filters-btn').addEventListener('click', () => {
+                searchInput.value = '';
+                activeFilters.searchTerm = '';
+                activeFilters.activeTag = null;
+
+                const allNewsTag = Array.from(document.querySelectorAll('.tag-button')).find(btn => btn.textContent === 'All News');
+                if (allNewsTag) setActiveTag(allNewsTag);
+
+                updateTagUrl(null);
+
+                const summary = document.querySelector('details summary');
+                if (summary) {
+                    summary.textContent = 'Campaigns';
+                    summary.parentElement.removeAttribute('open');
+                }
+
+                renderArticles();
+            });
             return;
         }
 


### PR DESCRIPTION
💡 What: Added a robust empty state for the news list. When search or filter criteria result in 0 articles, a friendly empty state is rendered with an SVG icon, clear messaging, and an actionable "Clear Search & Filters" button.
🎯 Why: Previously, a basic `<p>No news articles match your criteria.</p>` was shown. This was a dead end that didn't provide a clear path forward. The new empty state helps the user intuitively reset the search criteria to get back to browsing.
♿ Accessibility: The button is fully keyboard accessible, semantic HTML is used, and the text is clear and readable.

---
*PR created automatically by Jules for task [14226540322570707161](https://jules.google.com/task/14226540322570707161) started by @jaxsnjohnson*