### PR TITLE
⚡ Bolt: Filter dataset before applying expensive formatting operations

### DIFF
--- a/js/news.js
+++ b/js/news.js
@@ -75,6 +75,8 @@ document.addEventListener('DOMContentLoaded', () => {
             // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
             const updatedAtFormatter = new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
+            allArticles = allArticles.filter(isPublicArticle);
+
             // ⚡ Bolt: Pre-calculate lowercase search strings to prevent redundant string allocations and operations (.toLowerCase()) within render loops
             allArticles.forEach(article => {
                 if (article.updatedAt) {
@@ -83,8 +85,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 article.searchTitle = article.title.toLowerCase();
                 article.searchDescription = article.description.toLowerCase();
             });
-
-            allArticles = allArticles.filter(isPublicArticle);
 
             safeCapture('news_feed_loaded', { count: allArticles.length });
 


### PR DESCRIPTION
💡 What: Moved `.filter(isPublicArticle)` to execute *before* the `.forEach` loop in `js/news.js`.
🎯 Why: To avoid performing unnecessary CPU and memory intensive operations (like `new Date()` allocation, `Intl.DateTimeFormat().format()` instantiation/calls, and string `.toLowerCase()` allocations) on draft or scheduled articles that will just be immediately discarded.
📊 Impact: Saves CPU cycles and memory allocations by skipping hidden articles.
🔬 Measurement: Verified functionality by checking the diff, rendering the page via playwright tests and executing pytest.

---
*PR created automatically by Jules for task [5967108445636030470](https://jules.google.com/task/5967108445636030470) started by @jaxsnjohnson*