### PR TITLE
⚡ Bolt: Defer expensive date formatting to partitioned arrays

### DIFF
--- a/events.html
+++ b/events.html
@@ -348,18 +348,8 @@
                     const allEvents = await response.json();
 
                     // ⚡ Bolt: Pre-parse dates to avoid redundant Date instantiations in loops
-                    // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
-                    const monthShortFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
-                    const dateLongFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
-                    const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
-
                     allEvents.forEach(event => {
                         event.parsedDate = new Date(event.date.replace(/-/g, '\/'));
-                        event.formattedMonthShort = monthShortFormatter.format(event.parsedDate).toUpperCase();
-                        event.formattedDay2Digit = event.parsedDate.getDate().toString().padStart(2, '0');
-                        event.formattedDateLong = dateLongFormatter.format(event.parsedDate);
-                        event.formattedMonthYear = monthYearFormatter.format(event.parsedDate);
-                        event.formattedDate = event.parsedDate.getDate();
                     });
 
                     processAndRenderEvents(allEvents);
@@ -416,9 +406,13 @@
                     return;
                 }
 
+                // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
+                // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
+                const monthShortFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' });
+
                 upcomingEventsContainer.innerHTML = events.map(event => {
-                    const month = event.formattedMonthShort;
-                    const day = event.formattedDay2Digit;
+                    const month = monthShortFormatter.format(event.parsedDate).toUpperCase();
+                    const day = event.parsedDate.getDate().toString().padStart(2, '0');
                     const isRally = event.url === '/events/2026-06-30-Rally-at-McNary-Field.html';
                     const featuredClass = isRally ? 'border-4 border-brand-purple shadow-2xl ring-4 ring-violet-100' : (event.featured ? 'border-2 border-brand-purple shadow-lg' : 'border border-border-color');
                     
@@ -468,8 +462,12 @@
                 
                 if (moreEventsSection) moreEventsSection.classList.remove('hidden');
 
+                // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
+                // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
+                const dateLongFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+
                 stackedEventsContainer.innerHTML = events.map(event => {
-                    const formattedDate = event.formattedDateLong;
+                    const formattedDate = dateLongFormatter.format(event.parsedDate);
 
                     let calendarButton = '';
                     if (event.calendar_link) {
@@ -501,8 +499,12 @@
                     return;
                 }
 
+                // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
+                // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
+                const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
+
                 const groupedByMonth = events.reduce((acc, event) => {
-                    const monthYear = event.formattedMonthYear;
+                    const monthYear = monthYearFormatter.format(event.parsedDate);
                     if (!acc[monthYear]) acc[monthYear] = [];
                     acc[monthYear].push(event);
                     return acc;
@@ -511,7 +513,7 @@
                 pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
                     const eventListItems = monthEvents.map(event => `
                         <li class="py-2">
-                            <strong>${event.formattedDate}:</strong> ${escapeHTML(event.title)}
+                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
                     `).join('');


### PR DESCRIPTION
### 💡 What
Deferred `Intl.DateTimeFormat` instantiations and `.format()` calls out of the initial map array in `events.html` so that they only apply to the specific localized display scopes (`renderUpcomingEvents`, `renderStackedEvents`, `renderPastEvents`).

### 🎯 Why
Before this change, the `allEvents.forEach` loop pre-formatted each individual date for all 3 formats (`formattedMonthShort`, `formattedDateLong`, `formattedMonthYear`) on the entire `events.json` data structure (496+ events). This meant performing ~1,500 expensive formatting string operations when each section essentially only needs one specific format applied to a smaller slice.

### 📊 Impact
Reduces redundant `Intl.DateTimeFormat` calls drastically. The application now iterates over the data objects significantly fewer times, saving roughly ~1000 string allocations and computation cycles since formats are only calculated specifically for the view segments they render in.

### 🔬 Measurement
Check `events.html` rendering time over different sets of data. `safeCapture('events_loaded')` tracking should fire much quicker. Verified correctness locally with `site_quality_check.py` and checking local rendering to ensure variables resolved.

---
*PR created automatically by Jules for task [8484251690807691377](https://jules.google.com/task/8484251690807691377) started by @jaxsnjohnson*