### PR TITLE
🎨 Palette: Add helpful empty state to search page

### DIFF
--- a/test-pages/search.html
+++ b/test-pages/search.html
@@ -300,7 +300,20 @@
                 };
 
                 if (results.length === 0) {
-                    resultsContainer.innerHTML = `<p class="text-center text-text-secondary">No results found for "${escapeHTML(query)}".</p>`;
+                    resultsContainer.innerHTML = `
+                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <h3 class="text-xl font-bold text-brand-purple-dark mb-2">No results found</h3>
+                            <p class="text-text-secondary mb-6 text-center max-w-md">We couldn't find any results matching "${escapeHTML(query)}". Try adjusting your search term or clearing the filters.</p>
+                            <button id="reset-search-btn" class="inline-block px-6 py-3 border-2 border-brand-purple text-brand-purple font-bold rounded-lg hover:bg-brand-purple hover:text-white transition-colors" aria-label="Clear search text">Clear Search</button>
+                        </div>
+                    `;
+                    document.getElementById('reset-search-btn').addEventListener('click', () => {
+                        searchInput.value = '';
+                        performSearch();
+                    });
                     return;
                 }
                 


### PR DESCRIPTION
💡 **What:** Added a designed empty state component to the site search page (`test-pages/search.html`).
🎯 **Why:** Previously, when a user searched for a term with no results, they saw a plain, unstyled text string. The new empty state provides visual feedback (an icon and formatted typography) and an actionable "Clear Search" button, significantly improving usability and helping users recover from a dead end.
📸 **Before/After:** See attached Playwright verification screenshot for the new empty state look.
♿ **Accessibility:** Added an `aria-label` to the new "Clear Search" button for context. Safe interpolation of the user's query against XSS was maintained.

---
*PR created automatically by Jules for task [10933233259382501612](https://jules.google.com/task/10933233259382501612) started by @jaxsnjohnson*