### PR TITLE
⚡ Bolt: Remove redundant sorting in news feed

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,7 @@
 ## 2024-05-18 - [Premature Date Parsing for Filtering]
 **Learning:** [Instantiating `new Date()` for every item in a large dataset (e.g., hundreds of JSON events) just to filter by "upcoming" or "past" dates is an extremely slow performance anti-pattern. Because ISO-8601 dates (YYYY-MM-DD) are lexicographically sortable, direct string comparison (e.g. `event.date >= todayString`) achieves the same result ~50x faster.]
 **Action:** [Filter date strings directly using string comparison first, and defer instantiating `new Date()` only for the remaining slice of items that actually need advanced manipulation or formatting for display.]
+
+## 2024-05-18 - [Redundant Array Sorting]
+**Learning:** [Calling `.sort()` on an array that is already sorted, or can be trivially reversed, is a waste of O(n log n) operations. JavaScript's `.filter()` method preserves the original array order. If the source data is pre-sorted, the filtered result remains sorted in that same order.]
+**Action:** [Skip sorting entirely if the data is already in the desired order (e.g., "newest first"). If the opposite order is needed (e.g., "oldest first"), use the O(n) `.reverse()` method instead of re-evaluating the sort criteria.]

--- a/js/news.js
+++ b/js/news.js
@@ -256,12 +256,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Sort
-        if (activeFilters.sortOrder === 'newest') {
-            // ⚡ Bolt: Use fast string comparison instead of new Date() in sort loop (~25x faster)
-            filteredArticles.sort((a, b) => a.publishedAt < b.publishedAt ? 1 : (a.publishedAt > b.publishedAt ? -1 : 0));
-        } else {
-            // ⚡ Bolt: Use fast string comparison instead of new Date() in sort loop (~25x faster)
-            filteredArticles.sort((a, b) => a.publishedAt > b.publishedAt ? 1 : (a.publishedAt < b.publishedAt ? -1 : 0));
+        // ⚡ Bolt: allArticles is pre-sorted "newest" and .filter() preserves order.
+        // We can skip sorting for "newest", and use the much faster .reverse() for "oldest".
+        if (activeFilters.sortOrder === 'oldest') {
+            filteredArticles.reverse();
         }
 
         displayArticles(filteredArticles);


### PR DESCRIPTION
💡 **What:** Eliminated redundant array sorting in the `renderArticles` function of `js/news.js`. Replaced the `sort()` operation for the "oldest" view with `.reverse()`, and completely skipped the sorting block when the order is "newest".

🎯 **Why:** `allArticles` is explicitly pre-sorted newest-first when data is fetched. The `filteredArticles` list is generated via `Array.prototype.filter()`, which preserves this underlying order. Calling an $O(n \log n)$ `.sort()` method on data that is already correctly ordered is unnecessary overhead.

📊 **Impact:** Reduces main-thread execution time when switching search filters or toggling categories, specifically avoiding unneeded array sorts during high-frequency text-search filtering.

🔬 **Measurement:** Code review confirms the algorithmic optimization ($O(n \log n)$ reduced to $O(1)$ and $O(n)$ respectively). The test suite passes.

---
*PR created automatically by Jules for task [5848104816972491772](https://jules.google.com/task/5848104816972491772) started by @jaxsnjohnson*