### PR TITLE
Fix stale active tag UI when clearing news filters

### DIFF
--- a/js/news.js
+++ b/js/news.js
@@ -283,7 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 activeFilters.searchTerm = '';
                 activeFilters.activeTag = null;
 
-                const allNewsTag = Array.from(document.querySelectorAll('.tag-button')).find(btn => btn.textContent === 'All News');
+                const allNewsTag = Array.from(document.querySelectorAll('.tag-button')).find(btn => btn.textContent === 'All');
                 if (allNewsTag) setActiveTag(allNewsTag);
 
                 updateTagUrl(null);


### PR DESCRIPTION
### Motivation
- The reset handler cleared `activeFilters.activeTag` but searched for the wrong button label (`'All News'`) so the visual `active`/`aria-pressed` state could remain stale for the real `All` tag.

### Description
- Updated the reset lookup in `js/news.js` to find the `tag-button` whose `textContent` is `'All'` so `setActiveTag(...)` reactivates the correct button and keeps UI and filter state consistent.

### Testing
- No automated tests were available or run for this change; the fix is a single-line lookup correction in `js/news.js` and was verified by inspecting the updated diff and committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13f77d8fdc832fb7f3d9099ad0b2cc)