### PR TITLE
⚡ Bolt: Add lazy loading to offscreen images

### DIFF
--- a/about.html
+++ b/about.html
@@ -186,7 +186,8 @@
                     <p class="text-text-secondary leading-relaxed text-lg">Our members are the backbone of OSU, and together, we advocate for the respect, fair pay, and safe working conditions that all university employees deserve.</p>
                 </div>
                 <div class="order-1 lg:order-2">
-                    <img src="/images/8672a150-f638-4ad4-ba19-72ab754f74b8-homepage.webp" alt="SEIU 503 members rallying with signs" class="rounded-xl shadow-lg w-full h-auto object-cover" decoding="async" width="1280" height="720">
+                    <!-- ⚡ Bolt: Add loading="lazy" to defer offscreen images -->
+                    <img src="/images/8672a150-f638-4ad4-ba19-72ab754f74b8-homepage.webp" alt="SEIU 503 members rallying with signs" class="rounded-xl shadow-lg w-full h-auto object-cover" decoding="async" loading="lazy" width="1280" height="720">
                 </div>
             </div>
         </section>

--- a/leadership.html
+++ b/leadership.html
@@ -182,7 +182,8 @@
             <h2 class="text-4xl font-bold text-center mb-12">Executive Leadership</h2>
             <div class="flex flex-wrap justify-center gap-8">
                 <div class="bg-white rounded-xl border border-border-color text-center p-8 flex flex-col leadership-card">
-                    <img src="images/5aae970a-ef7b-4ce3-9510-b28435672bf7-jax-headshot.webp" alt="Jax SN Johnson" class="w-32 h-32 rounded-full mx-auto mb-4 border-4 border-white shadow-md" decoding="async" width="1280" height="1280">
+                    <!-- ⚡ Bolt: Add loading="lazy" to defer offscreen images -->
+                    <img src="images/5aae970a-ef7b-4ce3-9510-b28435672bf7-jax-headshot.webp" alt="Jax SN Johnson" class="w-32 h-32 rounded-full mx-auto mb-4 border-4 border-white shadow-md" decoding="async" loading="lazy" width="1280" height="1280">
                     <h3 class="text-2xl font-bold">Jax SN Johnson</h3>
                     <p class="text-brand-purple font-semibold">President &amp; Communications Chair</p>
                     <a href="mailto:083execteam@seiu503.org" class="text-sm text-brand-purple hover:underline mt-2 break-all">083execteam@seiu503.org</a>


### PR DESCRIPTION
💡 What: Added the `loading="lazy"` attribute to `<img>` tags in `about.html` and `leadership.html`. The hero images on `index.html` were intentionally left out as they are above the fold.
🎯 Why: Images without `loading="lazy"` load synchronously, impacting initial page load time. Deferring offscreen images improves initial render speed and saves bandwidth.
📊 Impact: Faster initial page load time and reduced initial data transfer.
🔬 Measurement: Verify that images below the fold are loaded lazily by inspecting network requests when scrolling.

---
*PR created automatically by Jules for task [1802225656149160981](https://jules.google.com/task/1802225656149160981) started by @jaxsnjohnson*