### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix image rendering bug caused by sanitizeUrl on img src

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -45,3 +45,8 @@
 **Vulnerability:** In `marketing/email-editor/index.html`, user-provided URLs in 'button' and 'links' blocks were injected into the `href` attributes of `<a>` tags. While the code used `escapeAttr()` (which escapes HTML entities), it did not sanitize the URL scheme, allowing `javascript:` or `data:` URIs to execute if the preview or exported HTML was interacted with.
 **Learning:** Even internal or admin-facing tools (like an email editor) are susceptible to DOM-based XSS if user input is rendered into critical attributes like `href`. Simple HTML escaping (`escapeHtml` / `escapeAttr`) is insufficient for URLs.
 **Prevention:** Ensure that a `sanitizeUrl` function (which explicitly blocks `javascript:` and `data:` schemes) is defined and applied to all user-controlled URLs before they are passed into `escapeAttr()` for insertion into HTML templates.
+
+## 2026-05-25 - [Removed sanitizeUrl on img src]
+**Vulnerability:** The application incorrectly used `sanitizeUrl` on `img src` attributes in `js/news.js`. While intended to prevent injection, `sanitizeUrl` explicitly strips `data:` URIs, which breaks legitimate base64-encoded images.
+**Learning:** Security functions must be applied only to their intended context. `sanitizeUrl` is designed to prevent `javascript:` and malicious `data:` scheme execution in contexts where they can execute (like `href` or `form action`). Browsers do not execute `javascript:` URIs in `<img> src` attributes, and blocking `data:` URIs unnecessarily breaks image rendering.
+**Prevention:** Removed `sanitizeUrl` from `<img src="...">` interpolations in `js/news.js`. Always verify the security context before applying a sanitization function to avoid breaking intended functionality.

--- a/js/news.js
+++ b/js/news.js
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         </div>
                         <div class="hidden lg:block">
                             <!-- ⚡ Bolt: Add loading="lazy" to defer offscreen images and improve initial page load time -->
-                            <img src="${escapeAttr(sanitizeUrl(article.image))}" alt="${escapeAttr(altText)}" class="w-full h-full object-cover" loading="lazy">
+                            <img src="${escapeAttr(article.image)}" alt="${escapeAttr(altText)}" class="w-full h-full object-cover" loading="lazy">
                         </div>
                     </div>
                 </a>
@@ -308,7 +308,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <div class="bg-white rounded-xl border border-border-color overflow-hidden flex flex-col h-full">
                 <a href="${escapeAttr(sanitizeUrl(article.url))}" class="group block" data-ph-event="news_article_click" data-ph-label="${escapeAttr(article.title)}" data-ph-metadata='{"position":"grid"}'>
                     <!-- ⚡ Bolt: Add loading="lazy" to defer offscreen images and improve initial page load time -->
-                    <img src="${escapeAttr(sanitizeUrl(article.image))}" alt="${escapeAttr(altText)}" class="w-full h-48 object-cover" loading="lazy">
+                    <img src="${escapeAttr(article.image)}" alt="${escapeAttr(altText)}" class="w-full h-48 object-cover" loading="lazy">
                 </a>
                 <div class="p-6 flex-grow">
                     <div class="flex items-center justify-between mb-2">


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix image rendering bug caused by sanitizeUrl on img src

**Severity:** MEDIUM
**Vulnerability:** A previous security update incorrectly applied `sanitizeUrl` to `img src` attributes. While `sanitizeUrl` is designed to prevent `javascript:` execution in contexts like `href`, it also explicitly strips `data:` URIs. This broke legitimate base64-encoded image sources.
**Impact:** Base64-encoded images would fail to render due to their source being replaced with `#`.
**Fix:** Removed the `sanitizeUrl` function wrapper from `<img src="...">` interpolations in `js/news.js`. Modern browsers do not execute `javascript:` URIs from image sources, so removing this function here restores functionality without introducing an XSS vulnerability. `escapeAttr` is still used to prevent attribute breakout.
**Verification:** Verified via `grep` that `sanitizeUrl` is no longer incorrectly used inside `img src` tags in `js/news.js`. All other security protections (like `escapeAttr`) remain intact.

---
*PR created automatically by Jules for task [8288966061668207330](https://jules.google.com/task/8288966061668207330) started by @jaxsnjohnson*