### PR TITLE
Add rel="noopener noreferrer" to rally email links

### DIFF
--- a/marketing/email/2026-03-12-Rally-at-OSU.html
+++ b/marketing/email/2026-03-12-Rally-at-OSU.html
@@ -42,7 +42,7 @@
                             <table role="presentation" border="0" cellpadding="0" cellspacing="0" align="center" style="margin: 0 auto 28px auto; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
                                 <tr>
                                     <td align="center" style="border-radius: 8px; background-color: #7C3AED;">
-                                        <a href="https://www.local083.org/rally" target="_blank" style="font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; padding: 14px 28px; border: 1px solid #7C3AED; border-radius: 8px; display: inline-block; font-weight: bold;">Sign Up Now</a>
+                                        <a href="https://www.local083.org/rally" target="_blank" rel="noopener noreferrer" style="font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; padding: 14px 28px; border: 1px solid #7C3AED; border-radius: 8px; display: inline-block; font-weight: bold;">Sign Up Now</a>
                                     </td>
                                 </tr>
                             </table>
@@ -53,7 +53,7 @@
                                         <h3 style="font-family: 'Lora', Georgia, serif; font-size: 22px; margin: 0 0 10px 0; color: #4C1D95;">Forward this to a coworker</h3>
                                         <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #374151; font-size: 16px; line-height: 1.6;">A bigger crowd makes a stronger statement. Share this email or send your coworkers the signup link so they can join us too.</p>
                                         <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0; font-size: 14px; color: #374151; line-height: 1.5;">
-                                            <a href="https://www.local083.org/rally" target="_blank" style="color: #7C3AED; word-break: break-all; text-decoration: underline;">https://www.local083.org/rally</a>
+                                            <a href="https://www.local083.org/rally" target="_blank" rel="noopener noreferrer" style="color: #7C3AED; word-break: break-all; text-decoration: underline;">https://www.local083.org/rally</a>
                                         </p>
                                     </td>
                                 </tr>


### PR DESCRIPTION
### Motivation
- Remediate a security issue where `target="_blank"` links to `/rally` (which immediately redirects to an external registration site) could retain `window.opener` in legacy/embedded browsers, enabling potential phishing via the opener tab.

### Description
- Add `rel="noopener noreferrer"` to the two rally signup anchors in `marketing/email/2026-03-12-Rally-at-OSU.html` while preserving the existing `target="_blank"` behavior.

### Testing
- Ran a small HTML parser check that confirmed both `/rally` `target="_blank"` anchors include `rel="noopener noreferrer"` and the check passed. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19cf40e508832f9bc092a66ad7d18a)