### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix CSS selector injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -50,3 +50,8 @@
 **Vulnerability:** The application incorrectly used `sanitizeUrl` on `img src` attributes in `js/news.js`. While intended to prevent injection, `sanitizeUrl` explicitly strips `data:` URIs, which breaks legitimate base64-encoded images.
 **Learning:** Security functions must be applied only to their intended context. `sanitizeUrl` is designed to prevent `javascript:` and malicious `data:` scheme execution in contexts where they can execute (like `href` or `form action`). Browsers do not execute `javascript:` URIs in `<img> src` attributes, and blocking `data:` URIs unnecessarily breaks image rendering.
 **Prevention:** Removed `sanitizeUrl` from `<img src="...">` interpolations in `js/news.js`. Always verify the security context before applying a sanitization function to avoid breaking intended functionality.
+
+## $(date +%Y-%m-%d) - [MEDIUM] Fix CSS Selector Injection in test-pages/annotated-page.html
+**Vulnerability:** User-controlled input (`targetId` derived from the `section` URL query parameter) was used directly to construct CSS selectors via `document.querySelector` inside `test-pages/annotated-page.html`. This creates a vulnerability to Client-Side DoS and Selector Injection, potentially causing unhandled exceptions if the parameter contains CSS control characters like brackets or quotes.
+**Learning:** Even internal testing or annotated tools that rely on URL parameters for state must defensively sanitize those parameters before using them in DOM manipulation functions like `querySelector()`.
+**Prevention:** Always use `CSS.escape()` to sanitize any dynamically generated or user-provided strings before concatenating them into a CSS selector string.

--- a/test-pages/annotated-page.html
+++ b/test-pages/annotated-page.html
@@ -419,8 +419,9 @@
                         return;
                     }
 
-                    const activeSection = contractContainer.querySelector(`.contract-section[data-target="${targetId}"]`);
-                    const activeAnnotation = annotationsContainer.querySelector(`#${targetId}`);
+                    const safeTargetId = CSS.escape(targetId);
+                    const activeSection = contractContainer.querySelector(`.contract-section[data-target="${safeTargetId}"]`);
+                    const activeAnnotation = annotationsContainer.querySelector(`#${safeTargetId}`);
 
                     if (activeSection && activeAnnotation) {
                         activeSection.classList.add('active');


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** User-controlled input (`targetId` derived from the `section` URL query parameter) was used directly to construct CSS selectors via `document.querySelector` inside `test-pages/annotated-page.html`.
🎯 **Impact:** This creates a vulnerability to Client-Side DoS and Selector Injection. If a user was tricked into visiting a URL with malformed parameters (e.g. containing quotes or brackets), it would cause an unhandled `DOMException`, breaking the page's JavaScript execution.
🔧 **Fix:** Sanitized `targetId` using `CSS.escape()` before using it in the CSS selector string.
✅ **Verification:** Ran automated checks (`pytest tests/`, `site_quality_check.py`), tests pass, and manually verified via Playwright that using `CSS.escape` resolves the DOM exception while still successfully querying both IDs and data-attributes.

---
*PR created automatically by Jules for task [2119041018399755707](https://jules.google.com/task/2119041018399755707) started by @jaxsnjohnson*