### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing rel='noopener noreferrer' to email editor links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,3 +55,13 @@
 **Vulnerability:** User-controlled URL parameter `targetId` was used directly in `document.querySelector()` without being escaped in `test-pages/annotated-page.html`.
 **Learning:** Constructing CSS selectors using unescaped user input can lead to Selector Injection. Attackers can inject arbitrary selectors or execute Client-Side Denial of Service (DoS) by providing excessively complex or malformed inputs, which could break the JavaScript execution.
 **Prevention:** Always sanitize and escape user-controlled data using `CSS.escape()` before interpolating it into a CSS selector string.
+
+## 2026-06-05 - [Fix Reverse Tabnabbing Vulnerability]
+**Vulnerability:** Instances of  were found missing the  attribute, leaving the application susceptible to reverse tabnabbing attacks.
+**Learning:** Using  without proper  attributes can allow newly opened tabs to hijack the original tab's  object.
+**Prevention:** Ensured  is added to all user-facing  anchor tags dynamically interpolated in client-side HTML.
+
+## 2026-06-05 - [Fix Reverse Tabnabbing Vulnerability]
+**Vulnerability:** Instances of target="_blank" were found missing the rel="noopener noreferrer" attribute, leaving the application susceptible to reverse tabnabbing attacks.
+**Learning:** Using target="_blank" without proper rel attributes can allow newly opened tabs to hijack the original tab's window.opener object.
+**Prevention:** Ensured rel="noopener noreferrer" is added to all user-facing target="_blank" anchor tags dynamically interpolated in client-side HTML.

--- a/marketing/email-editor/index.html
+++ b/marketing/email-editor/index.html
@@ -968,7 +968,7 @@
                             <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="100%" style="margin: 0 0 24px 0;">
                                 <tr>
                                     <td align="center" style="${tdStyle}">
-                                        <a href="${escapeAttr(sanitizeUrl(block.url))}" target="_blank" style="${linkStyle}">${inlineText(block.label)}</a>
+                                        <a href="${escapeAttr(sanitizeUrl(block.url))}" target="_blank" rel="noopener noreferrer" style="${linkStyle}">${inlineText(block.label)}</a>
                                     </td>
                                 </tr>
                             </table>`;
@@ -1008,7 +1008,7 @@
             if (block.type === "links") {
                 const links = parsePipedLines(block.links).map((row) => `
                                         <p style="margin: 0 0 10px 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.6; color: #374151;">
-                                            <a href="${escapeAttr(sanitizeUrl(row.value))}" target="_blank" style="color: #6D28D9; text-decoration: underline; word-break: break-word;">${inlineText(row.label)}</a>
+                                            <a href="${escapeAttr(sanitizeUrl(row.value))}" target="_blank" rel="noopener noreferrer" style="color: #6D28D9; text-decoration: underline; word-break: break-word;">${inlineText(row.label)}</a>
                                         </p>`).join("");
                 return `
                             <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #F9FAFB; border-radius: 8px; border: 1px solid #D1D5DB; margin-bottom: 24px;">


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Reverse tabnabbing vulnerability where user-generated `href` links opening in new tabs (`target="_blank"`) lack `rel="noopener noreferrer"`.
🎯 Impact: Target windows could potentially execute JavaScript on the origin window object via `window.opener`, posing a security risk.
🔧 Fix: Added `rel="noopener noreferrer"` dynamically to email editor links to secure the context isolation.
✅ Verification: Ran testing suite and site quality checks. Reviewed via manual code inspection.

---
*PR created automatically by Jules for task [14868667902596390496](https://jules.google.com/task/14868667902596390496) started by @jaxsnjohnson*