### PR TITLE
⚡ Bolt: Remove redundant RegExp in rendering loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2024-05-18 - [Redundant Array Sorting]
 **Learning:** [Calling `.sort()` on an array that is already sorted, or can be trivially reversed, is a waste of O(n log n) operations. JavaScript's `.filter()` method preserves the original array order. If the source data is pre-sorted, the filtered result remains sorted in that same order.]
 **Action:** [Skip sorting entirely if the data is already in the desired order (e.g., "newest first"). If the opposite order is needed (e.g., "oldest first"), use the O(n) `.reverse()` method instead of re-evaluating the sort criteria.]
+
+## 2026-06-06 - [Redundant RegExp in Render Loop]
+**Learning:** [Instantiating `new RegExp()` inside a mapping loop (e.g. `results.map`) causes redundant object creation and pattern compilation for every item being rendered, especially when the regex pattern (like a search query) is identical for all iterations. This degrades performance significantly when rendering many items.]
+**Action:** [Move `new RegExp()` instantiation outside of the loop, compute it once conditionally, and reuse the compiled regex inside the loop to avoid redundant object creation.]

--- a/test-pages/search.html
+++ b/test-pages/search.html
@@ -333,15 +333,20 @@
                     return;
                 }
                 
+                // ⚡ Bolt: Move RegExp instantiation outside the map loop to avoid redundant object creation
+                let queryRegex = null;
+                if (query) {
+                    const escapedQuery = escapeHTML(query);
+                    const safeQuery = escapedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape regex control characters
+                    queryRegex = new RegExp(`(${safeQuery})`, 'gi');
+                }
+
                 resultsContainer.innerHTML = results.map(item => {
                     // Create a snippet and highlight the query term
                     let snippet = item.content.substring(0, 150) + '...';
                     snippet = escapeHTML(snippet);
-                    if (query) {
-                        const escapedQuery = escapeHTML(query);
-                        const safeQuery = escapedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape regex control characters
-                        const regex = new RegExp(`(${safeQuery})`, 'gi');
-                        snippet = snippet.replace(regex, `<mark class="bg-yellow-200">$1</mark>`);
+                    if (queryRegex) {
+                        snippet = snippet.replace(queryRegex, `<mark class="bg-yellow-200">$1</mark>`);
                     }
 
                     return `


### PR DESCRIPTION
💡 What: Hoisted the RegExp creation outside of the `results.map` loop in `test-pages/search.html`.
🎯 Why: Instantiating `new RegExp` for the exact same query pattern on every iteration of a map loop is an expensive performance anti-pattern. Moving it out avoids redundant object creation and pattern compilation.
📊 Impact: Reduces CPU and memory overhead during search rendering, particularly for large result sets. Performance scales better as O(1) regex compilation instead of O(n).
🔬 Measurement: Verify by interacting with the search page (`test-pages/search.html`) and observing faster rendering. Checked manually and all python tests passed successfully.

---
*PR created automatically by Jules for task [16355515802080250564](https://jules.google.com/task/16355515802080250564) started by @jaxsnjohnson*