### PR TITLE
⚡ Bolt: Hoist RegExp instantiation outside render loop in search.html

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2024-05-18 - [Redundant Array Sorting]
 **Learning:** [Calling `.sort()` on an array that is already sorted, or can be trivially reversed, is a waste of O(n log n) operations. JavaScript's `.filter()` method preserves the original array order. If the source data is pre-sorted, the filtered result remains sorted in that same order.]
 **Action:** [Skip sorting entirely if the data is already in the desired order (e.g., "newest first"). If the opposite order is needed (e.g., "oldest first"), use the O(n) `.reverse()` method instead of re-evaluating the sort criteria.]
+
+## 2026-06-09 - [Hoisting RegExp outside render loops]
+**Learning:** [Instantiating `new RegExp()` inside a mapping or rendering loop (e.g., `results.map`) causes redundant object creation and pattern compilation for every item, leading to performance degradation, especially with large datasets or complex patterns. It is safe to reuse a global `RegExp` instance with `String.prototype.replace()` because `replace()` automatically resets the regex's `lastIndex` property, avoiding state leakage issues.]
+**Action:** [To prevent wasting CPU and memory, always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant across iterations.]

--- a/test-pages/search.html
+++ b/test-pages/search.html
@@ -333,14 +333,19 @@
                     return;
                 }
                 
+                // ⚡ Bolt: Hoist RegExp instantiation outside of the map loop to prevent redundant compilations
+                let regex = null;
+                if (query) {
+                    const escapedQuery = escapeHTML(query);
+                    const safeQuery = escapedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape regex control characters
+                    regex = new RegExp(`(${safeQuery})`, 'gi');
+                }
+
                 resultsContainer.innerHTML = results.map(item => {
                     // Create a snippet and highlight the query term
                     let snippet = item.content.substring(0, 150) + '...';
                     snippet = escapeHTML(snippet);
-                    if (query) {
-                        const escapedQuery = escapeHTML(query);
-                        const safeQuery = escapedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape regex control characters
-                        const regex = new RegExp(`(${safeQuery})`, 'gi');
+                    if (regex) {
                         snippet = snippet.replace(regex, `<mark class="bg-yellow-200">$1</mark>`);
                     }
 


### PR DESCRIPTION
💡 **What:** Hoisted the `new RegExp` instantiation and query string escaping outside the `results.map` loop in `test-pages/search.html`.

🎯 **Why:** To prevent redundant regular expression compilation and object allocation for every individual item in the search results loop, eliminating an unnecessary main thread bottleneck. 

📊 **Impact:** Significantly reduces CPU overhead and memory allocation during the DOM rendering phase of the search results grid, especially on large datasets.

🔬 **Measurement:** Verified that the search functionality continues to correctly highlight matched queries. Reviewed the JS implementation and confirmed it matches Bolt's guidelines. Verified there are no `.pyc` files or cache directories lingering around, running `python3 scripts/site_quality_check.py --strict-placeholders` and `pytest tests/` successfully.

---
*PR created automatically by Jules for task [13729790416544253044](https://jules.google.com/task/13729790416544253044) started by @jaxsnjohnson*