### PR TITLE
🎨 Palette: Add helpful empty state for initial search page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,6 @@ Critical UX/accessibility learnings only.
 ## 2026-05-18 - [Add visual and semantic loading states]
 **Learning:** Plain text loading indicators (like "Loading...") can feel unresponsive and lack proper semantic meaning for assistive technologies. Replacing them with an animated visual spinner and a `role="status"` wrapper ensures both sighted and screen-reader users understand the system is processing information.
 **Action:** Always use a visual indicator (like a spinner) accompanied by semantic `role="status"` and visually hidden text for asynchronous loading states.
+## 2026-06-11 - [Add empty state for initial search screen]
+**Learning:** Initial search screens often present users with a blank slate that can feel uninviting or confusing. A plain text prompt like "Type to search" lacks visual hierarchy and polish.
+**Action:** Replace plain text search prompts with a visually distinct empty state component. This should include a relevant icon (like a magnifying glass or search symbol), a clear, bold heading ("Search the site"), and supportive descriptive text guiding the user on what they can search for. This reduces cognitive load and makes the search interface feel more approachable and professional.

--- a/test-pages/search.html
+++ b/test-pages/search.html
@@ -357,7 +357,15 @@
             }
             
             function displayInitialMessage() {
-                 resultsContainer.innerHTML = `<p class="text-center text-text-secondary">Type in the box above to search the site.</p>`;
+                 resultsContainer.innerHTML = `
+                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <h3 class="text-xl font-bold text-brand-purple-dark mb-2">Search the site</h3>
+                            <p class="text-text-secondary mb-6 text-center max-w-md">Type in the box above to search for articles, events, and resources.</p>
+                        </div>
+                 `;
             }
 
             // --- Mobile Menu Toggle ---


### PR DESCRIPTION
💡 **What:** Upgraded the plain text placeholder on the initial `/test-pages/search.html` screen to a styled, structured empty state component with an icon and clear guidance.
🎯 **Why:** To make the initial search experience more visually inviting and consistent with other empty states across the site. A plain text message lacks hierarchy, while a distinct component clearly guides user action.
📸 **Before/After:** The change is visible when loading the search page before typing a query.
♿ **Accessibility:** Uses semantic HTML, descriptive text, and maintains existing structural container classes.

---
*PR created automatically by Jules for task [6153605624993592639](https://jules.google.com/task/6153605624993592639) started by @jaxsnjohnson*