### PR TITLE
⚡ Bolt: Optimize date grouping from O(N) to O(1) per group

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2026-05-18 - [Group-Based Date Parsing Avoidance]
+**Learning:** [When grouping data by a time period (like months or years) derived from an ISO-8601 string (e.g., `YYYY-MM-DD`), instantiating `new Date()` and calling `Intl.DateTimeFormat` on *every single item* to determine its group key is an O(N) performance anti-pattern.]
+**Action:** [Extract the group key directly from the date string using substrings (e.g., `event.date.substring(0, 7)` for `YYYY-MM`). Then, after grouping is complete, instantiate `new Date()` and format the display string (e.g. "August 2026") only *once* per unique group key (O(1) per group).]

--- a/events.html
+++ b/events.html
@@ -532,21 +532,29 @@
                 // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
+                // ⚡ Bolt: Group events by extracting YYYY-MM directly from the ISO string
+                // This avoids parsing new Date() and calling Intl.DateTimeFormat for every event (O(N) -> O(1))
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    const monthKey = event.date.substring(0, 7);
+                    if (!acc[monthKey]) acc[monthKey] = [];
+                    acc[monthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
-                    const eventListItems = monthEvents.map(event => `
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthKey, monthEvents]) => {
+                    // Only parse the date for the monthKey once per group
+                    const monthDate = new Date(monthKey + '-01T00:00:00');
+                    const monthYear = monthYearFormatter.format(monthDate);
+
+                    const eventListItems = monthEvents.map(event => {
+                        // We still need the day number for the list item
+                        const dayNumber = parseInt(event.date.substring(8, 10), 10);
+                        return `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${dayNumber}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
-                    `).join('');
+                    `}).join('');
 
                     return `
                         <details class="bg-white rounded-xl border border-border-color group transition-shadow duration-300 open:shadow-md">


### PR DESCRIPTION
💡 What: Modified `events.html`'s `renderPastEvents` to group events by extracting the `YYYY-MM` prefix directly from the ISO date string, rather than instantiating `new Date()` and calling `Intl.DateTimeFormat` on every single event.
🎯 Why: Instantiating and formatting dates on every single iteration of a loop scales O(N) with the number of items and is a known performance anti-pattern.
📊 Impact: Reduces expensive date parsing and formatting operations from O(N) to O(1) per month group.
🔬 Measurement: Verify by rendering the past events section in `events.html` and confirming the groups (e.g. "August 2026") remain correctly formatted and grouped.

---
*PR created automatically by Jules for task [3817328268568736671](https://jules.google.com/task/3817328268568736671) started by @jaxsnjohnson*