### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerabilities

### DIFF
--- a/2026-bargaining/index.html
+++ b/2026-bargaining/index.html
@@ -248,7 +248,7 @@
                 <div class="mt-8 flex flex-col sm:flex-row sm:items-center gap-4 justify-center lg:justify-start">
                     <a href="https://seiu503.tfaforms.net/759" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener noreferrer">Join the CAT</a>
                     <a href="https://seiu503signup.org" class="btn btn-secondary w-full sm:w-auto" target="_blank" rel="noopener noreferrer">Become a Member</a>
-                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline w-full sm:w-auto" target="_blank" rel="noopener">Open the Flyer</a>
+                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline w-full sm:w-auto" target="_blank" rel="noopener noreferrer">Open the Flyer</a>
                 </div>
             </div>
             <div class="lg:w-2/5 flex justify-center">
@@ -297,7 +297,7 @@
                     </article>
                 </div>
                 <div class="mt-8 flex flex-col sm:flex-row gap-4">
-                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline w-full sm:w-auto text-center" target="_blank" rel="noopener">Download the Bilingual Flyer</a>
+                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline w-full sm:w-auto text-center" target="_blank" rel="noopener noreferrer">Download the Bilingual Flyer</a>
                     <a href="https://seiu503.tfaforms.net/759" class="btn btn-secondary w-full sm:w-auto text-center" target="_blank" rel="noopener noreferrer">Join the Contract Action Team</a>
                 </div>
             </div>
@@ -625,7 +625,7 @@
                     <h3 class="font-bold text-xl">Economics: They Say / We Say</h3>
                     <p class="text-text-secondary mt-1">See the update on economics proposals and open the flyer for members.</p>
                 </a>
-                <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="block bg-white p-6 rounded-xl border border-border-color hover:shadow-xl hover:border-brand-purple transition-all duration-300 hover:-translate-y-1" target="_blank" rel="noopener">
+                <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="block bg-white p-6 rounded-xl border border-border-color hover:shadow-xl hover:border-brand-purple transition-all duration-300 hover:-translate-y-1" target="_blank" rel="noopener noreferrer">
                     <h3 class="font-bold text-xl">They Say / We Say Flyer</h3>
                     <p class="text-text-secondary mt-1">Open the bargaining flyer on economics proposals to share with coworkers.</p>
                 </a>

--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
                     <div class="mt-8 flex flex-col sm:flex-row sm:items-center gap-4 justify-center md:justify-start">
                         <a href="/rally" class="btn btn-primary w-full sm:w-auto" data-ph-event="cta_click" data-ph-label="Homepage Hero Rally Signup">Sign Up for the Rally</a>
                         <a href="/2026-bargaining/index.html" class="btn btn-secondary w-full sm:w-auto" data-ph-event="cta_click" data-ph-label="Homepage Hero Bargaining Hub">Read the Bargaining Hub</a>
-                        <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline w-full sm:w-auto" target="_blank" rel="noopener" data-ph-event="cta_click" data-ph-label="Homepage Hero They Say We Say Flyer">Open Flyer</a>
+                        <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline w-full sm:w-auto" target="_blank" rel="noopener noreferrer" data-ph-event="cta_click" data-ph-label="Homepage Hero They Say We Say Flyer">Open Flyer</a>
                     </div>
                 </div>
                 <div class="md:w-2/5 mt-12 md:mt-0 flex justify-center">
@@ -273,7 +273,7 @@
                 <div class="mt-6 grid grid-cols-1 md:grid-cols-4 gap-3">
                     <a href="/rally" class="btn btn-primary text-center" data-ph-event="cta_click" data-ph-label="Promo Rally Signup">Sign Up for Rally</a>
                     <a href="/2026-bargaining/index.html" class="btn btn-secondary text-center" data-ph-event="cta_click" data-ph-label="Promo View Bargaining Hub">Read the Bargaining Hub</a>
-                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline text-center" target="_blank" rel="noopener" data-ph-event="cta_click" data-ph-label="Promo Open They Say We Say Flyer">Open the Flyer</a>
+                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-outline text-center" target="_blank" rel="noopener noreferrer" data-ph-event="cta_click" data-ph-label="Promo Open They Say We Say Flyer">Open the Flyer</a>
                     <a href="https://seiu503.tfaforms.net/759" class="btn btn-outline text-center" target="_blank" rel="noopener noreferrer" data-ph-event="cta_click" data-ph-label="Promo Join CAT">Join the CAT</a>
                 </div>
             </div>

--- a/news/2026-05-07-economics-they-say-we-say.html
+++ b/news/2026-05-07-economics-they-say-we-say.html
@@ -192,7 +192,7 @@
                     <p>Updated <time datetime="2026-05-07">May 7, 2026</time></p>
                 </div>
                 <div class="mt-8 flex flex-col sm:flex-row sm:items-center justify-center gap-4">
-                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener">Open Proposal Flyer</a>
+                    <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener noreferrer">Open Proposal Flyer</a>
                     <a href="/2026-bargaining/index.html" class="btn btn-outline w-full sm:w-auto">Return to Bargaining Hub</a>
                 </div>
             </header>
@@ -203,8 +203,8 @@
                 <div class="mb-8 rounded-xl border border-brand-purple/15 bg-brand-purple-light/35 p-6">
                     <h2 class="text-2xl font-bold">Source note</h2>
                     <div class="article-content mt-3 text-base text-text-secondary space-y-3">
-                        <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
-                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This page uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
+                        <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener noreferrer">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
+                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener noreferrer">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This page uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
                         <p>If this page and the contract PDF ever differ, the contract PDF is the source of truth. The <strong>Our union says</strong> and <strong>Why it matters</strong> sections below are our union's analysis.</p>
                     </div>
                 </div>
@@ -225,7 +225,7 @@
                         <p>Use the flyer to talk with coworkers about the proposals and why turnout matters while economics is on the table.</p>
                     </div>
                     <div class="mt-6 flex flex-col sm:flex-row gap-4">
-                        <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener">Open the Proposal Flyer</a>
+                        <a href="/2026-bargaining/Higher-Ed-They-Say-We-Say-Flyer.pdf" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener noreferrer">Open the Proposal Flyer</a>
                         <a href="/2026-bargaining/index.html" class="btn btn-outline w-full sm:w-auto">More Bargaining Updates</a>
                     </div>
                 </section>

--- a/resources/corvallis-civic-action.html
+++ b/resources/corvallis-civic-action.html
@@ -199,8 +199,8 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Find Your Exact Representatives</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregonlegislature.gov/FindYourLegislator/leg-districts.html" target="_blank" rel="noopener">Oregon Legislature: Find Your Legislator</a></li>
-                    <li><a href="https://www.house.gov/representatives/find-your-representative" target="_blank" rel="noopener">U.S. House: Find Your Representative</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/FindYourLegislator/leg-districts.html" target="_blank" rel="noopener noreferrer">Oregon Legislature: Find Your Legislator</a></li>
+                    <li><a href="https://www.house.gov/representatives/find-your-representative" target="_blank" rel="noopener noreferrer">U.S. House: Find Your Representative</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Corvallis Area Contacts (Verified February 10, 2026)</h2>
@@ -208,22 +208,22 @@
                 <ul class="list-disc pl-5 space-y-2">
                     <li><strong>Mayor and City Council:</strong> <a href="mailto:mayorandcouncil@corvallisoregon.gov">mayorandcouncil@corvallisoregon.gov</a></li>
                     <li><strong>City Hall:</strong> coming soon</li>
-                    <li><a href="https://www.corvallisoregon.gov/mc/page/contact-city-council" target="_blank" rel="noopener">Official City Council Contact Page</a></li>
+                    <li><a href="https://www.corvallisoregon.gov/mc/page/contact-city-council" target="_blank" rel="noopener noreferrer">Official City Council Contact Page</a></li>
                 </ul>
 
                 <h3 class="text-2xl font-bold text-brand-purple-dark">Oregon Legislature</h3>
                 <ul class="list-disc pl-5 space-y-2">
                     <li><strong>Sen. Sara Gelser Blouin (District 8):</strong> coming soon, <a href="mailto:Sen.SaraGelser@oregonlegislature.gov">Sen.SaraGelser@oregonlegislature.gov</a></li>
                     <li><strong>Rep. Sarah Finger McDonald (District 16):</strong> coming soon, <a href="mailto:Rep.SarahFingerMcDonald@oregonlegislature.gov">Rep.SarahFingerMcDonald@oregonlegislature.gov</a></li>
-                    <li><a href="https://www.oregonlegislature.gov/gelser" target="_blank" rel="noopener">Sen. Gelser Blouin official page</a></li>
-                    <li><a href="https://www.oregonlegislature.gov/mcdonald" target="_blank" rel="noopener">Rep. Finger McDonald official page</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/gelser" target="_blank" rel="noopener noreferrer">Sen. Gelser Blouin official page</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/mcdonald" target="_blank" rel="noopener noreferrer">Rep. Finger McDonald official page</a></li>
                 </ul>
 
                 <h3 class="text-2xl font-bold text-brand-purple-dark">Federal (Oregon)</h3>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><strong>Sen. Ron Wyden:</strong> <a href="https://www.wyden.senate.gov/contact/email-ron" target="_blank" rel="noopener">Email form</a> | <a href="https://www.wyden.senate.gov/contact/office-locations" target="_blank" rel="noopener">Office locations</a></li>
-                    <li><strong>Sen. Jeff Merkley:</strong> <a href="https://www.merkley.senate.gov/connect/contact/" target="_blank" rel="noopener">Email form</a></li>
-                    <li><strong>Rep. Val Hoyle (OR-04):</strong> <a href="https://hoyle.house.gov/contact/email-val" target="_blank" rel="noopener">Email form</a></li>
+                    <li><strong>Sen. Ron Wyden:</strong> <a href="https://www.wyden.senate.gov/contact/email-ron" target="_blank" rel="noopener noreferrer">Email form</a> | <a href="https://www.wyden.senate.gov/contact/office-locations" target="_blank" rel="noopener noreferrer">Office locations</a></li>
+                    <li><strong>Sen. Jeff Merkley:</strong> <a href="https://www.merkley.senate.gov/connect/contact/" target="_blank" rel="noopener noreferrer">Email form</a></li>
+                    <li><strong>Rep. Val Hoyle (OR-04):</strong> <a href="https://hoyle.house.gov/contact/email-val" target="_blank" rel="noopener noreferrer">Email form</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">How to Write an Effective Message (60-120 Seconds to Read)</h2>

--- a/resources/elr-contacted-you-playbook.html
+++ b/resources/elr-contacted-you-playbook.html
@@ -267,7 +267,7 @@
                     <li><strong>Christopher Anderson</strong> - Employee Labor Relations Officer, coming soon</li>
                     <li><strong>Scott Southard</strong> - Senior Employee Labor Relations Officer (Classified employee bargaining matters), coming soon</li>
                 </ul>
-                <p>Source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener">OSU ELR Contact Directory</a></p>
+                <p>Source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener noreferrer">OSU ELR Contact Directory</a></p>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>
                 <ul class="list-disc pl-5 space-y-2">

--- a/resources/oregon-boli-rights.html
+++ b/resources/oregon-boli-rights.html
@@ -249,12 +249,12 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Official BOLI Links</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/your-rights-at-work.aspx" target="_blank" rel="noopener">Your Rights at Work</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/Pages/wage-and-hour-complaint-form.aspx" target="_blank" rel="noopener">Wage and Hour Complaint</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/paychecks.aspx" target="_blank" rel="noopener">Paycheck and Final Pay Rules</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/minimum-wage.aspx" target="_blank" rel="noopener">Minimum Wage Rates</a></li>
-                    <li><a href="https://www.oregon.gov/boli/civil-rights/pages/discrimination-at-work.aspx" target="_blank" rel="noopener">Discrimination at Work</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/retaliation-at-work.aspx" target="_blank" rel="noopener">Retaliation at Work</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/your-rights-at-work.aspx" target="_blank" rel="noopener noreferrer">Your Rights at Work</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/Pages/wage-and-hour-complaint-form.aspx" target="_blank" rel="noopener noreferrer">Wage and Hour Complaint</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/paychecks.aspx" target="_blank" rel="noopener noreferrer">Paycheck and Final Pay Rules</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/minimum-wage.aspx" target="_blank" rel="noopener noreferrer">Minimum Wage Rates</a></li>
+                    <li><a href="https://www.oregon.gov/boli/civil-rights/pages/discrimination-at-work.aspx" target="_blank" rel="noopener noreferrer">Discrimination at Work</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/retaliation-at-work.aspx" target="_blank" rel="noopener noreferrer">Retaliation at Work</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>

--- a/resources/oregon-elr-rights.html
+++ b/resources/oregon-elr-rights.html
@@ -213,8 +213,8 @@
                     <li><strong>Christopher Anderson</strong> - Employee Labor Relations Officer (Classified Employees, Professional Faculty), coming soon</li>
                     <li><strong>Scott Southard</strong> - Senior Employee Labor Relations Officer (Classified employee bargaining matters), coming soon</li>
                 </ul>
-                <p>Official directory source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener">OSU Employee and Labor Relations contact page</a></p>
-                <p>State public-sector labor relations context: <a href="https://www.oregon.gov/das/HR/Pages/LRU.aspx" target="_blank" rel="noopener">Oregon DAS Labor Relations Unit</a></p>
+                <p>Official directory source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener noreferrer">OSU Employee and Labor Relations contact page</a></p>
+                <p>State public-sector labor relations context: <a href="https://www.oregon.gov/das/HR/Pages/LRU.aspx" target="_blank" rel="noopener noreferrer">Oregon DAS Labor Relations Unit</a></p>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">When to Contact Your Union First</h2>
                 <ul class="list-disc pl-5 space-y-3">

--- a/resources/oregon-erb-rights.html
+++ b/resources/oregon-erb-rights.html
@@ -248,11 +248,11 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Official Oregon ERB Links</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregon.gov/erb/Pages/AboutERB.aspx" target="_blank" rel="noopener">About ERB</a></li>
-                    <li><a href="https://www.oregon.gov/erb/Pages/PECBA.aspx" target="_blank" rel="noopener">PECBA Overview</a></li>
-                    <li><a href="https://www.oregon.gov/erb/Pages/ULP.aspx" target="_blank" rel="noopener">Unfair Labor Practice (ULP)</a></li>
-                    <li><a href="https://www.oregon.gov/erb/pages/forms.aspx" target="_blank" rel="noopener">ERB Forms</a></li>
-                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors243.html" target="_blank" rel="noopener">ORS Chapter 243 (PECBA and ERB statutes)</a></li>
+                    <li><a href="https://www.oregon.gov/erb/Pages/AboutERB.aspx" target="_blank" rel="noopener noreferrer">About ERB</a></li>
+                    <li><a href="https://www.oregon.gov/erb/Pages/PECBA.aspx" target="_blank" rel="noopener noreferrer">PECBA Overview</a></li>
+                    <li><a href="https://www.oregon.gov/erb/Pages/ULP.aspx" target="_blank" rel="noopener noreferrer">Unfair Labor Practice (ULP)</a></li>
+                    <li><a href="https://www.oregon.gov/erb/pages/forms.aspx" target="_blank" rel="noopener noreferrer">ERB Forms</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors243.html" target="_blank" rel="noopener noreferrer">ORS Chapter 243 (PECBA and ERB statutes)</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>

--- a/resources/ors-244-ethics-guide.html
+++ b/resources/ors-244-ethics-guide.html
@@ -246,10 +246,10 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Official ORS 244 / OGEC Links</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors244.html" target="_blank" rel="noopener">ORS 244 Full Text</a></li>
-                    <li><a href="https://www.oregon.gov/ogec/pages/laws.aspx" target="_blank" rel="noopener">OGEC Laws and Rules</a></li>
-                    <li><a href="https://www.oregon.gov/ogec/Pages/Guide-for-Public-Officials.aspx" target="_blank" rel="noopener">OGEC Guide for Public Officials</a></li>
-                    <li><a href="https://www.oregon.gov/ogec/Documents/Public%20Officials%20Guide/Guide_for_Public_Officials.pdf" target="_blank" rel="noopener">OGEC Public Officials Guide (PDF)</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors244.html" target="_blank" rel="noopener noreferrer">ORS 244 Full Text</a></li>
+                    <li><a href="https://www.oregon.gov/ogec/pages/laws.aspx" target="_blank" rel="noopener noreferrer">OGEC Laws and Rules</a></li>
+                    <li><a href="https://www.oregon.gov/ogec/Pages/Guide-for-Public-Officials.aspx" target="_blank" rel="noopener noreferrer">OGEC Guide for Public Officials</a></li>
+                    <li><a href="https://www.oregon.gov/ogec/Documents/Public%20Officials%20Guide/Guide_for_Public_Officials.pdf" target="_blank" rel="noopener noreferrer">OGEC Public Officials Guide (PDF)</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>

--- a/test-pages/2026-03-30-31-management-says-we-say.html
+++ b/test-pages/2026-03-30-31-management-says-we-say.html
@@ -193,7 +193,7 @@
                     <p>Review draft updated <time datetime="2026-04-08">April 8, 2026</time></p>
                 </div>
                 <div class="mt-8 flex flex-col sm:flex-row sm:items-center justify-center gap-4">
-                    <a href="/resources/seiu_cba_2022-2026.pdf" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener">Open Our Contract (PDF)</a>
+                    <a href="/resources/seiu_cba_2022-2026.pdf" class="btn btn-primary w-full sm:w-auto" target="_blank" rel="noopener noreferrer">Open Our Contract (PDF)</a>
                     <a href="/2026-bargaining/index.html" class="btn btn-outline w-full sm:w-auto">Return to Bargaining Hub</a>
                 </div>
             </header>
@@ -204,8 +204,8 @@
                 <div class="mb-8 rounded-xl border border-brand-purple/15 bg-brand-purple-light/35 p-6">
                     <h2 class="text-2xl font-bold">Source note for this draft</h2>
                     <div class="article-content mt-3 text-base text-text-secondary space-y-3">
-                        <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
-                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This draft uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
+                        <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener noreferrer">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
+                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener noreferrer">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This draft uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
                         <p>If this page and the contract PDF ever differ, the contract PDF is the source of truth. The <strong>Our union says</strong> and <strong>Why it matters</strong> sections below are our union's analysis.</p>
                     </div>
                 </div>

--- a/test-pages/contract-summary.html
+++ b/test-pages/contract-summary.html
@@ -174,7 +174,7 @@
             <h1 class="text-5xl font-bold">Contract Summary (2022–2026)</h1>
             <p class="mt-4 text-lg text-text-secondary max-w-3xl mx-auto">This page is a plain-language guide to the SEIU Local 503 OSU contract. It highlights the major topics covered in the agreement and points you to the official PDF for the exact language.</p>
             <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                <a href="/resources/seiu_cba_2022-2026.pdf" class="btn btn-outline" target="_blank" rel="noopener">Open Full Contract (PDF)</a>
+                <a href="/resources/seiu_cba_2022-2026.pdf" class="btn btn-outline" target="_blank" rel="noopener noreferrer">Open Full Contract (PDF)</a>
                 <a href="/resources/stewards.html" class="btn btn-primary">Talk to a Steward</a>
             </div>
         </div>
@@ -227,7 +227,7 @@
             <div class="mt-12 text-center border-t border-border-color pt-8">
                 <h3 class="text-2xl font-bold">Need the Official Language?</h3>
                 <p class="text-text-secondary my-4">Download or open the full contract PDF for the exact terms, rates, and timelines.</p>
-                <a href="/resources/seiu_cba_2022-2026.pdf" class="btn btn-outline" target="_blank" rel="noopener">Open Full Contract (PDF)</a>
+                <a href="/resources/seiu_cba_2022-2026.pdf" class="btn btn-outline" target="_blank" rel="noopener noreferrer">Open Full Contract (PDF)</a>
             </div>
         </article>
     </main>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Multiple external links used `target="_blank"` with only `rel="noopener"`, but lacked `noreferrer`. While `noopener` mitigates the primary reverse tabnabbing risk (window.opener hijacking), `noreferrer` provides defense-in-depth for older browsers and improves privacy by not leaking the `Referer` header to external sites.
🎯 Impact: Minor risk to user privacy via leaked Referer headers, and potential tabnabbing risk in very outdated browsers.
🔧 Fix: Updated all `rel="noopener"` instances to `rel="noopener noreferrer"`.
✅ Verification: `git diff` confirms changes. `pytest` and `site_quality_check` run correctly.

---
*PR created automatically by Jules for task [444415972072274257](https://jules.google.com/task/444415972072274257) started by @jaxsnjohnson*