### PR TITLE
⚡ Bolt: [Group Dates by Substring Optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2026-05-18 - [Substring Grouping for ISO-8601 Strings]
+**Learning:** [Grouping large arrays of objects by date (e.g., grouping events by month) by parsing `new Date()` and applying `Intl.DateTimeFormat` on every single item is a massive O(N) performance anti-pattern. Because ISO-8601 strings (YYYY-MM-DD) natively encode the group key (YYYY-MM) via a simple substring, we can extract the group key directly without any date parsing.]
+**Action:** [When grouping data by a time period derived from ISO-8601 strings, extract the group key via substring (e.g., `date.substring(0, 7)`) instead of instantiating `new Date()`. Apply date formatting (`Intl.DateTimeFormat.format()`) only once per unique group to reduce O(N) formatting operations to O(1) per group.]

--- a/events.html
+++ b/events.html
@@ -532,21 +532,29 @@
                 // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
-                const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                // ⚡ Bolt: Extract group key via substring instead of O(N) date parsing
+                const groupedByMonthKey = events.reduce((acc, event) => {
+                    const monthKey = event.date.substring(0, 7); // e.g., "2024-05"
+                    if (!acc[monthKey]) acc[monthKey] = [];
+                    acc[monthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
-                    const eventListItems = monthEvents.map(event => `
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonthKey).map(([monthKey, monthEvents]) => {
+                    // ⚡ Bolt: Parse and format date only once per group (O(1) per group)
+                    const [yearStr, monthStr] = monthKey.split('-');
+                    const groupDate = new Date(yearStr, parseInt(monthStr, 10) - 1, 1);
+                    const monthYear = monthYearFormatter.format(groupDate);
+
+                    const eventListItems = monthEvents.map(event => {
+                        const day = parseInt(event.date.substring(8, 10), 10);
+                        return `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${day}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
-                    `).join('');
+                        `;
+                    }).join('');
 
                     return `
                         <details class="bg-white rounded-xl border border-border-color group transition-shadow duration-300 open:shadow-md">


### PR DESCRIPTION
💡 What: Updated `events.html` to group events by extracting the "YYYY-MM" string directly from ISO-8601 strings rather than calling `new Date()` and `Intl.DateTimeFormat` formatting on every object. Now, we group via string slice and only format the date string once per group instead of N times.
🎯 Why: Instantiating `new Date()` and calling `Intl.DateTimeFormat.format()` is expensive. Applying this in a `.reduce()` loop for all items in an array is an O(N) performance bottleneck for data the user might never see. Extracting a group string from ISO-8601 dates avoids O(N) date processing, changing the operation to O(1) format operations per unique date group. 
📊 Impact: Considerably faster event grid rendering. Less main-thread blocking on event load.
🔬 Measurement: Run `events.html` and profile the performance overhead of executing `renderPastEvents()`.

---
*PR created automatically by Jules for task [9155502663812237060](https://jules.google.com/task/9155502663812237060) started by @jaxsnjohnson*