### PR TITLE
⚡ Bolt: Optimize past events grouping to O(1) date operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2024-05-18 - [Group Formatting Avoidance]
+**Learning:** [When grouping datasets by date (e.g., separating past events by month), running `new Date()` and `Intl.DateTimeFormat.format()` inside the inner loop for every item prior to group assignment takes O(N) formatting operations. This bottleneck wastes CPU because all elements within a group yield the exact same formatted string.]
+**Action:** [To optimize grouping data by a time period derived from ISO-8601 strings, extract the group key via fast string operations like `substring(0, 7)` (for YYYY-MM) to form the groups. Then, format the date only once per unique group key in the outer render loop, reducing operations from O(N) to O(1) per group.]

--- a/events.html
+++ b/events.html
@@ -533,17 +533,21 @@
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    // ⚡ Bolt: Group by substring (YYYY-MM) instead of formatting each Date (O(N) -> O(1) date ops per group)
+                    const monthKey = event.date.substring(0, 7);
+                    if (!acc[monthKey]) acc[monthKey] = [];
+                    acc[monthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthKey, monthEvents]) => {
+                    // ⚡ Bolt: Apply date formatting only once per unique group
+                    const groupDate = new Date(monthKey + '-01T00:00:00');
+                    const monthYear = monthYearFormatter.format(groupDate);
+
                     const eventListItems = monthEvents.map(event => `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${parseInt(event.date.substring(8, 10), 10)}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
                     `).join('');


### PR DESCRIPTION
💡 What: Optimized the "past events" grouping logic in `events.html` by extracting the group key using string `substring(0, 7)` directly from the ISO-8601 date, and formatting the date string only once per unique month group.

🎯 Why: To fix an O(N) performance bottleneck. The original logic was unnecessarily instantiating a `new Date()` and calling `Intl.DateTimeFormat.format()` for *every single past event* before grouping them. These are computationally expensive operations, especially when many events map to the exact same month string.

📊 Impact: Reduces expensive date instantiation and formatting operations from O(N) (once per event) to O(1) (once per unique month group). For a dataset of 100 past events spanning 10 months, this avoids 90 redundant `new Date()` and `format()` calls during rendering.

🔬 Measurement: The change preserves the correct local-time parsing and formatting behavior while streamlining the logic. Run `python3 scripts/site_quality_check.py --strict-placeholders` and visually verify the archived events section on `events.html` to confirm it accurately renders.

---
*PR created automatically by Jules for task [13406734987014769398](https://jules.google.com/task/13406734987014769398) started by @jaxsnjohnson*