### PR TITLE
⚡ Bolt: Optimize date grouping in events using substring

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+## 2026-05-18 - [Optimizing Date Grouping via Substring]
+**Learning:** [Grouping collections of date-stamped objects (like events) by instantiating `new Date()` and calling `Intl.DateTimeFormat` on every single object is an O(N) performance bottleneck.]
+**Action:** [Extract the group key using string slicing (e.g. `event.date.substring(0, 7)`) instead of `new Date()`. Apply the expensive date formatting operations only once per unique group when rendering to reduce O(N) date operations to O(1) per group.]

--- a/events.html
+++ b/events.html
@@ -532,21 +532,30 @@
                 // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
+                // ⚡ Bolt: Optimize date grouping by extracting ISO-8601 substring instead of instantiating new Date() and formatting each item
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    const monthKey = event.date.substring(0, 7); // YYYY-MM
+                    if (!acc[monthKey]) acc[monthKey] = [];
+                    acc[monthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
-                    const eventListItems = monthEvents.map(event => `
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthKey, monthEvents]) => {
+                    // ⚡ Bolt: Apply expensive date formatting only once per unique group
+                    const [year, month] = monthKey.split('-');
+                    const groupDate = new Date(year, parseInt(month, 10) - 1, 1);
+                    const monthYear = monthYearFormatter.format(groupDate);
+
+                    const eventListItems = monthEvents.map(event => {
+                        // ⚡ Bolt: Extract day directly from substring instead of instantiating new Date()
+                        const day = parseInt(event.date.substring(8, 10), 10);
+                        return `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${day}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
-                    `).join('');
+                        `;
+                    }).join('');
 
                     return `
                         <details class="bg-white rounded-xl border border-border-color group transition-shadow duration-300 open:shadow-md">


### PR DESCRIPTION
### 💡 What
Optimized the `groupedByMonth` function in `events.html` by extracting the group key using string slicing (`event.date.substring(0, 7)`) instead of instantiating `new Date()` and formatting each item individually. The expensive date formatting (`Intl.DateTimeFormat`) is now applied only once per unique group when rendering. Also optimized extracting the day using `substring`.

### 🎯 Why
Grouping collections of date-stamped objects by instantiating `new Date()` and calling `Intl.DateTimeFormat` on every single object is an O(N) performance bottleneck.

### 📊 Impact
Reduces O(N) date formatting operations to O(1) per month group. Reduces array grouping loop time by avoiding `new Date()` allocations and implicit formatter evaluations.

### 🔬 Measurement
Review `events.html` rendering performance; fewer total operations will be spent in `reduce` map filtering.

---
*PR created automatically by Jules for task [17285898051954993986](https://jules.google.com/task/17285898051954993986) started by @jaxsnjohnson*