### PR TITLE
🎨 Palette: Add required attributes and visual indicators to inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,6 @@ Critical UX/accessibility learnings only.
 ## 2026-05-18 - [Add visual and semantic loading states]
 **Learning:** Plain text loading indicators (like "Loading...") can feel unresponsive and lack proper semantic meaning for assistive technologies. Replacing them with an animated visual spinner and a `role="status"` wrapper ensures both sighted and screen-reader users understand the system is processing information.
 **Action:** Always use a visual indicator (like a spinner) accompanied by semantic `role="status"` and visually hidden text for asynchronous loading states.
+## 2026-05-18 - [Add required indicators to critical inputs]
+**Learning:** Users and screen readers need clear indicators for mandatory fields, even outside of traditional <form> submissions (e.g., calculator inputs). Relying on implicit requirement degrades UX and accessibility.
+**Action:** Always add `required` and `aria-required="true"` attributes to essential <input> elements, and pair them with a visual indicator (like a red * with `aria-hidden="true"`) in the associated <label>.

--- a/news/2025-11-01-COLA.html
+++ b/news/2025-11-01-COLA.html
@@ -281,10 +281,10 @@
                     </summary>
                     <div class="mt-4 space-y-4">
                         <div>
-                            <label for="current-pay" class="block text-sm font-medium text-text-secondary mb-2">Enter your current hourly or monthly pay:</label>
+                            <label for="current-pay" class="block text-sm font-medium text-text-secondary mb-2">Enter your current hourly or monthly pay: <span class="text-red-500" aria-hidden="true">*</span></label>
                             <div class="relative">
                                 <span class="absolute inset-y-0 left-0 pl-3 flex items-center text-text-secondary" aria-hidden="true">$</span>
-                                <input type="number" id="current-pay" name="current-pay" class="pl-7 pr-4 py-2 w-full max-w-xs border bg-white border-border-color rounded-md shadow-sm focus:ring-brand-purple focus:border-brand-purple" placeholder="e.g., 20.50" min="0" step="0.01" inputmode="decimal">
+                                <input type="number" id="current-pay" name="current-pay" class="pl-7 pr-4 py-2 w-full max-w-xs border bg-white border-border-color rounded-md shadow-sm focus:ring-brand-purple focus:border-brand-purple" placeholder="e.g., 20.50" min="0" step="0.01" inputmode="decimal" required aria-required="true">
                             </div>
                         </div>
                         <div class="space-y-2 text-base">

--- a/test-pages/calculator.html
+++ b/test-pages/calculator.html
@@ -215,12 +215,12 @@
                 <h2 class="text-3xl font-bold">Estimate your monthly dues</h2>
                 <div class="mt-6 space-y-6">
                     <div>
-                        <label for="hourly-wage" class="block text-lg font-medium text-text-primary">Hourly wage ($)</label>
-                        <input type="number" id="hourly-wage" name="hourly-wage" class="mt-2 block w-full p-3 border border-border-color rounded-md shadow-sm focus:ring-brand-purple focus:border-brand-purple text-lg" placeholder="e.g., 22.50" step="0.01" min="0" inputmode="decimal">
+                        <label for="hourly-wage" class="block text-lg font-medium text-text-primary">Hourly wage ($) <span class="text-red-500" aria-hidden="true">*</span></label>
+                        <input type="number" id="hourly-wage" name="hourly-wage" class="mt-2 block w-full p-3 border border-border-color rounded-md shadow-sm focus:ring-brand-purple focus:border-brand-purple text-lg" placeholder="e.g., 22.50" step="0.01" min="0" inputmode="decimal" required aria-required="true">
                     </div>
                     <div>
-                        <label for="hours-week" class="block text-lg font-medium text-text-primary">Hours worked per week</label>
-                        <input type="number" id="hours-week" name="hours-week" class="mt-2 block w-full p-3 border border-border-color rounded-md shadow-sm focus:ring-brand-purple focus:border-brand-purple text-lg" placeholder="e.g., 40" value="40" min="0" inputmode="decimal">
+                        <label for="hours-week" class="block text-lg font-medium text-text-primary">Hours worked per week <span class="text-red-500" aria-hidden="true">*</span></label>
+                        <input type="number" id="hours-week" name="hours-week" class="mt-2 block w-full p-3 border border-border-color rounded-md shadow-sm focus:ring-brand-purple focus:border-brand-purple text-lg" placeholder="e.g., 40" value="40" min="0" inputmode="decimal" required aria-required="true">
                         <p id="hours-cap-message" class="mt-2 text-sm text-text-secondary hidden">Hours above 40 are capped at 40 for dues estimates because overtime is not included.</p>
                     </div>
                 </div>


### PR DESCRIPTION
💡 What: Added `required` and `aria-required="true"` to critical numeric inputs and a red asterisk (`*`) to their respective labels in the calculator tool and COLA news page.
🎯 Why: To make it explicitly clear to all users (both visually and via screen readers) that these fields are mandatory for the tools to calculate dues and raises correctly. Implicit requirements degrade UX.
📸 Before/After: Visual asterisks now exist next to the "Hourly wage", "Hours worked", and "current pay" labels.
♿ Accessibility: Assistive technologies will now explicitly announce these fields as required.

Reference: Added learning to Palette journal.

---
*PR created automatically by Jules for task [3640152013201668485](https://jules.google.com/task/3640152013201668485) started by @jaxsnjohnson*