### PR TITLE
⚡ Bolt: Optimize date grouping in events.html

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2024-05-18 - [O(N) Date Operations in Grouping]
+**Learning:** [Grouping data by a time period (like months or years) by parsing a `new Date()` and applying `Intl.DateTimeFormat` on every single item in a large dataset results in O(N) expensive operations.]
+**Action:** [To optimize grouping data by a time period derived from ISO-8601 strings, extract the group key via substring (e.g., `date.substring(0, 7)`) rather than parsing a `new Date()` and formatting each item individually. Apply date formatting only once per unique group to reduce O(N) date operations to O(1) per group.]

--- a/events.html
+++ b/events.html
@@ -528,22 +528,25 @@
                     return;
                 }
 
-                // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
-                // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
-                const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
-
+                // ⚡ Bolt: Group events using fast substring keys (YYYY-MM) instead of parsing new Date()
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    const yearMonthKey = event.date.substring(0, 7);
+                    if (!acc[yearMonthKey]) acc[yearMonthKey] = [];
+                    acc[yearMonthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
+                // ⚡ Bolt: Cache Intl.DateTimeFormat objects to drastically reduce instantiation overhead
+                const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
+
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([yearMonthKey, monthEvents]) => {
+                    // ⚡ Bolt: Format the localized month string only once per unique month group
+                    const groupDate = new Date(`${yearMonthKey}-01T00:00:00`);
+                    const monthYear = monthYearFormatter.format(groupDate);
+
                     const eventListItems = monthEvents.map(event => `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${parseInt(event.date.substring(8, 10), 10)}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
                     `).join('');


### PR DESCRIPTION
💡 What: Replaced $O(N)$ date parsing in `events.html` grouping loop with $O(1)$ substring keys (`YYYY-MM`). Date parsing and `Intl.DateTimeFormat` are now only called once per unique group.
🎯 Why: Instantiating `new Date()` and formatting localized date strings on every single item in a dataset causes unnecessary CPU overhead, especially as the list of past events grows.
📊 Impact: Reduces expensive Date operations from $O(N)$ (where $N$ is total events) to $O(M)$ (where $M$ is unique months), making rendering faster and saving memory.
🔬 Measurement: Open `events.html` containing a large list of past events in a performance profiler and observe the reduced overhead from JavaScript's built-in date functions.

---
*PR created automatically by Jules for task [14385538567807176696](https://jules.google.com/task/14385538567807176696) started by @jaxsnjohnson*