### PR TITLE
🎨 Palette: Add role=status to empty state messages for screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,7 @@ Critical UX/accessibility learnings only.
 ## 2026-05-18 - [Add visual and semantic loading states]
 **Learning:** Plain text loading indicators (like "Loading...") can feel unresponsive and lack proper semantic meaning for assistive technologies. Replacing them with an animated visual spinner and a `role="status"` wrapper ensures both sighted and screen-reader users understand the system is processing information.
 **Action:** Always use a visual indicator (like a spinner) accompanied by semantic `role="status"` and visually hidden text for asynchronous loading states.
+
+## 2024-05-24 - [Accessible Empty States]
+**Learning:** Dynamically rendered empty UI states (like "No upcoming events") are not natively announced by screen readers if they lack semantic wrapper attributes.
+**Action:** When dynamically rendering empty UI states (e.g., 'No articles found' or 'No upcoming events'), ensure the container element includes the `role="status"` attribute so screen readers automatically announce the state change.

--- a/events.html
+++ b/events.html
@@ -413,7 +413,7 @@
                 if (!upcomingEventsContainer) return;
                 if (events.length === 0) {
                     upcomingEventsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                             </svg>
@@ -517,7 +517,7 @@
                 if (!pastEventsContainer) return;
                 if (events.length === 0) {
                     pastEventsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>

--- a/index.html
+++ b/index.html
@@ -718,7 +718,7 @@
                         }).join('');
                     } else {
                         eventsContainer.innerHTML = `
-                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                                 </svg>
@@ -783,7 +783,7 @@
                         `;
                     } else {
                         newsGridContainer.innerHTML = `
-                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15M9 11l3 3m0 0l3-3m-3 3V8" />
                                 </svg>

--- a/js/news.js
+++ b/js/news.js
@@ -270,7 +270,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function displayArticles(articles) {
         if (articles.length === 0) {
             articlesGrid.innerHTML = `
-                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>


### PR DESCRIPTION
💡 **What:** Added the `role="status"` attribute to empty state containers (e.g., "No articles found", "No upcoming events") that are dynamically rendered via JavaScript in `index.html`, `events.html`, and `news.js`.
🎯 **Why:** To ensure screen readers automatically announce these empty state messages, improving the accessibility and clarity of the application when data fetches return zero results.
♿ **Accessibility:** Dynamically rendered empty states were previously silent to screen readers. Adding `role="status"` guarantees they are politely announced as soon as they are added to the DOM.

---
*PR created automatically by Jules for task [2171572867156414341](https://jules.google.com/task/2171572867156414341) started by @jaxsnjohnson*