### PR TITLE
⚡ Bolt: Optimize grouping and formatting in past events list

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2026-06-23 - [Grouping by Time Period Optimization]
+**Learning:** [When grouping data by a time period (like months or years) derived from ISO-8601 strings, parsing a `new Date()` and formatting each item individually to find the group key is an expensive O(N) operation. It's much faster to extract the group key using string substrings (e.g., `date.substring(0, 7)`) and apply date formatting only once per unique group (e.g., O(1) per group).]
+**Action:** [To optimize grouping by a time period derived from ISO-8601 strings, extract the group key via substring rather than parsing and formatting each item. Apply date formatting only once per unique group to reduce O(N) date operations to O(1) per group.]

--- a/events.html
+++ b/events.html
@@ -533,20 +533,26 @@
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    // ⚡ Bolt: Group by YYYY-MM substring to avoid new Date() and formatting per item
+                    const groupKey = event.date.substring(0, 7);
+                    if (!acc[groupKey]) acc[groupKey] = [];
+                    acc[groupKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
-                    const eventListItems = monthEvents.map(event => `
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([groupKey, monthEvents]) => {
+                    // ⚡ Bolt: Format the date only once per group instead of once per item
+                    const parsedDate = new Date(groupKey.replace(/-/g, '/') + '/01');
+                    const monthYear = monthYearFormatter.format(parsedDate);
+
+                    const eventListItems = monthEvents.map(event => {
+                        const day = parseInt(event.date.substring(8, 10), 10);
+                        return `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${day}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
-                    `).join('');
+                    `}).join('');
 
                     return `
                         <details class="bg-white rounded-xl border border-border-color group transition-shadow duration-300 open:shadow-md">


### PR DESCRIPTION
**💡 What:** 
Updated `renderPastEvents` in `events.html` to group past events using substring operations (`YYYY-MM`) and directly extract the day via `substring` + `parseInt`. This avoids instantiating `new Date()` and calling `Intl.DateTimeFormat().format()` on every individual event within the array.

**🎯 Why:**
The original implementation performed an expensive O(N) date parse and format for *every* past event in order to construct a grouping key. By taking advantage of the guaranteed zero-padded ISO-8601 string format, we can safely extract grouping and rendering data directly from strings. This reduces expensive date instantiation overhead to an O(1) operation per unique group.

**📊 Impact:** 
Considerable performance improvement in the browser's main thread rendering loop on `events.html`, reducing CPU overhead and allocation latency when dealing with large volumes of archived events.

**🔬 Measurement:** 
Load the page with extensive past events data to visually observe uninterrupted rendering, or utilize local Chrome DevTools Performance traces to quantify the execution time reduction of `renderPastEvents`. Ensure all dates render correctly.

---
*PR created automatically by Jules for task [18214760102985592863](https://jules.google.com/task/18214760102985592863) started by @jaxsnjohnson*