### PR TITLE
Fix privacy-settings control semantics on public pages

### DIFF
--- a/2026-bargaining/bargaining-survey-landing-page.html
+++ b/2026-bargaining/bargaining-survey-landing-page.html
@@ -252,9 +252,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/2026-bargaining/index.html
+++ b/2026-bargaining/index.html
@@ -766,9 +766,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/2026-bargaining/survey-tracker.html
+++ b/2026-bargaining/survey-tracker.html
@@ -212,9 +212,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/404.html
+++ b/404.html
@@ -225,9 +225,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/about.html
+++ b/about.html
@@ -443,9 +443,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -280,9 +280,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events.html
+++ b/events.html
@@ -317,9 +317,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-08-21-Membership-Meeting.html
+++ b/events/2025-08-21-Membership-Meeting.html
@@ -311,9 +311,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-08-28-Steward-Meeting.html
+++ b/events/2025-08-28-Steward-Meeting.html
@@ -248,9 +248,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-03-CAT-Meeting.html
+++ b/events/2025-09-03-CAT-Meeting.html
@@ -251,9 +251,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-03-New-Employee-Orientation.html
+++ b/events/2025-09-03-New-Employee-Orientation.html
@@ -241,9 +241,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-04-Bargaining-Committee-Meeting.html
+++ b/events/2025-09-04-Bargaining-Committee-Meeting.html
@@ -231,9 +231,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-09-Executive-Team-Meeting.html
+++ b/events/2025-09-09-Executive-Team-Meeting.html
@@ -244,9 +244,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-10-CAT-Meeting.html
+++ b/events/2025-09-10-CAT-Meeting.html
@@ -312,9 +312,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-13-Bargaining-Conference.html
+++ b/events/2025-09-13-Bargaining-Conference.html
@@ -297,9 +297,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-16-University-Day.html
+++ b/events/2025-09-16-University-Day.html
@@ -308,9 +308,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-09-17-Comms-Meeting.html
+++ b/events/2025-09-17-Comms-Meeting.html
@@ -302,9 +302,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-01-CAT-Meeting.html
+++ b/events/2025-10-01-CAT-Meeting.html
@@ -312,9 +312,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-02-Bargaining-Committee-Meeting.html
+++ b/events/2025-10-02-Bargaining-Committee-Meeting.html
@@ -280,9 +280,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-09-Executive-Team-Meeting.html
+++ b/events/2025-10-09-Executive-Team-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-16-Membership-Meeting.html
+++ b/events/2025-10-16-Membership-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-22-CAT-Meeting.html
+++ b/events/2025-10-22-CAT-Meeting.html
@@ -310,9 +310,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-23-Bowling.html
+++ b/events/2025-10-23-Bowling.html
@@ -334,9 +334,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-10-30-Stewards-Meeting.html
+++ b/events/2025-10-30-Stewards-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-11-05-CAT-Meeting.html
+++ b/events/2025-11-05-CAT-Meeting.html
@@ -316,9 +316,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-11-06-Bargaining-Committee-Meeting.html
+++ b/events/2025-11-06-Bargaining-Committee-Meeting.html
@@ -280,9 +280,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-11-13-Executive-Team-Meeting.html
+++ b/events/2025-11-13-Executive-Team-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-11-20-Membership-Meeting.html
+++ b/events/2025-11-20-Membership-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-11-27-Stewards-Meeting.html
+++ b/events/2025-11-27-Stewards-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-12-03-CAT-Meeting.html
+++ b/events/2025-12-03-CAT-Meeting.html
@@ -304,9 +304,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-12-04-Bargaining-Committee-Meeting.html
+++ b/events/2025-12-04-Bargaining-Committee-Meeting.html
@@ -280,9 +280,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-12-11-Executive-Team-Meeting.html
+++ b/events/2025-12-11-Executive-Team-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2025-12-18-Membership-Meeting.html
+++ b/events/2025-12-18-Membership-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-01-07-CAT-Meeting.html
+++ b/events/2026-01-07-CAT-Meeting.html
@@ -304,9 +304,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-01-08-Executive-Team-Meeting.html
+++ b/events/2026-01-08-Executive-Team-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-01-15-Membership-Meeting.html
+++ b/events/2026-01-15-Membership-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-01-29-Stewards-Meeting.html
+++ b/events/2026-01-29-Stewards-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-02-05-Bargaining-Committee-Meeting.html
+++ b/events/2026-02-05-Bargaining-Committee-Meeting.html
@@ -280,9 +280,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-02-05-CAT-Meeting.html
+++ b/events/2026-02-05-CAT-Meeting.html
@@ -314,9 +314,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-02-12-Bargaining-Zoom-Observation.html
+++ b/events/2026-02-12-Bargaining-Zoom-Observation.html
@@ -296,9 +296,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-02-12-Executive-Team-Meeting.html
+++ b/events/2026-02-12-Executive-Team-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-02-19-Membership-Meeting.html
+++ b/events/2026-02-19-Membership-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-02-26-Stewards-Meeting.html
+++ b/events/2026-02-26-Stewards-Meeting.html
@@ -293,9 +293,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-03-10-CAT-Meeting.html
+++ b/events/2026-03-10-CAT-Meeting.html
@@ -314,9 +314,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-03-11-Facilities-Membership-Meeting.html
+++ b/events/2026-03-11-Facilities-Membership-Meeting.html
@@ -274,9 +274,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-03-31-Rally-at-OSU.html
+++ b/events/2026-03-31-Rally-at-OSU.html
@@ -301,9 +301,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-04-01-New-Employee-Orientation.html
+++ b/events/2026-04-01-New-Employee-Orientation.html
@@ -295,9 +295,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/events/2026-04-16-Membership-Meeting.html
+++ b/events/2026-04-16-Membership-Meeting.html
@@ -308,9 +308,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -499,9 +499,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/leadership.html
+++ b/leadership.html
@@ -289,9 +289,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news.html
+++ b/news.html
@@ -294,9 +294,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2025-08-22-Icecream.html
+++ b/news/2025-08-22-Icecream.html
@@ -337,9 +337,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2025-10-01-bargaining-survey-live.html
+++ b/news/2025-10-01-bargaining-survey-live.html
@@ -303,9 +303,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2025-10-27-bowling-striking-success.html
+++ b/news/2025-10-27-bowling-striking-success.html
@@ -319,9 +319,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2025-11-01-COLA.html
+++ b/news/2025-11-01-COLA.html
@@ -386,9 +386,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2025-11-03-bargaining-survey-update.html
+++ b/news/2025-11-03-bargaining-survey-update.html
@@ -314,9 +314,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2025-12-15-fighting-for-higher-education.html
+++ b/news/2025-12-15-fighting-for-higher-education.html
@@ -396,9 +396,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-01-09-kickoff.html
+++ b/news/2026-01-09-kickoff.html
@@ -354,9 +354,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-02-04-upcoming-bargaining-events.html
+++ b/news/2026-02-04-upcoming-bargaining-events.html
@@ -318,9 +318,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-02-04-zoom-backgrounds.html
+++ b/news/2026-02-04-zoom-backgrounds.html
@@ -336,9 +336,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-02-12-bargaining-observation-time-change.html
+++ b/news/2026-02-12-bargaining-observation-time-change.html
@@ -263,9 +263,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-03-11-protecting-our-hardship-leave.html
+++ b/news/2026-03-11-protecting-our-hardship-leave.html
@@ -308,9 +308,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-04-16-membership-meeting-update.html
+++ b/news/2026-04-16-membership-meeting-update.html
@@ -496,9 +496,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-04-21-new-sublocal-083-leadership-team.html
+++ b/news/2026-04-21-new-sublocal-083-leadership-team.html
@@ -335,9 +335,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/news/2026-05-07-economics-they-say-we-say.html
+++ b/news/2026-05-07-economics-they-say-we-say.html
@@ -642,9 +642,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources.html
+++ b/resources.html
@@ -369,9 +369,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/bylaws.html
+++ b/resources/bylaws.html
@@ -406,9 +406,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/corvallis-civic-action.html
+++ b/resources/corvallis-civic-action.html
@@ -338,9 +338,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/costco.html
+++ b/resources/costco.html
@@ -276,9 +276,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/elr-contacted-you-playbook.html
+++ b/resources/elr-contacted-you-playbook.html
@@ -345,9 +345,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/hardship-leave.html
+++ b/resources/hardship-leave.html
@@ -268,9 +268,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/oregon-boli-rights.html
+++ b/resources/oregon-boli-rights.html
@@ -333,9 +333,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/oregon-elr-rights.html
+++ b/resources/oregon-elr-rights.html
@@ -340,9 +340,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/oregon-erb-rights.html
+++ b/resources/oregon-erb-rights.html
@@ -331,9 +331,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/ors-244-ethics-guide.html
+++ b/resources/ors-244-ethics-guide.html
@@ -328,9 +328,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/stewards.html
+++ b/resources/stewards.html
@@ -268,9 +268,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/weingarten-rights.html
+++ b/resources/weingarten-rights.html
@@ -294,9 +294,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/resources/zoom-backgrounds.html
+++ b/resources/zoom-backgrounds.html
@@ -415,9 +415,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>

--- a/test-pages.html
+++ b/test-pages.html
@@ -229,9 +229,7 @@
             <div class="mt-10 pt-8 border-t border-gray-700 text-center space-y-2">
                 <p class="text-text-secondary text-sm">&copy; 2026 SEIU Local 503, Sublocal 083. All rights reserved.</p>
                 <p class="text-text-secondary text-xs">
-                    <a href="#" class="underline hover:text-brand-purple" onclick="event.preventDefault(); (localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">
-                        Privacy settings
-                    </a>
+                    <button type="button" class="underline hover:text-brand-purple" onclick="(localStorage.getItem('ph_opt_out') === '1' ? phOptIn() : phOptOut());">Privacy settings</button>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Fixed highest-impact a11y blocker by replacing non-navigation footer privacy controls (`href="#"` + JS handler) with semantic `<button type="button">` across 79 public-facing HTML files (site pages in `*.html`, `events/`, `news/`, `resources/`, `2026-bargaining/`).
- Added no functional changes beyond control semantics and preserved existing behavior.

## Confirmed issue
- WCAG/Section 508 blocker: a public control was exposed as a link (`href="#"`) for privacy settings, creating an incorrect interactive role and unnecessary URL-jump semantics for assistive technologies and keyboard users.

## Fixes made
- Replaced footer privacy settings control markup in all modified public pages with a `button` element while keeping the same `onclick` handler (`phOptIn/phOptOut`).
- Kept analytics scripts and page content unchanged.

## Checks run
- `python3 scripts/site_quality_check.py --strict-placeholders` (pass: 88 public pages, 0 errors, 0 warnings)
- `python3 -m unittest tests.test_site_quality_check` (pass)
- Repository scan confirming no remaining `href="#"` + `ph_opt_out` pattern in public page scope.
- Attempted Playwright DOM/a11y check; browser launch fails in this environment with `MachPortRendezvousServer` permission errors, so interactive runtime scan was unavailable.

## Exceptions / remaining concerns
- Remaining `href="#"` instances are still present in a small set of public pages for placeholder CTAs (for example Zoom/TBD or volunteer placeholder) and were intentionally left unchanged in this blocker-focused pass.
- Non-public collateral (`marketing/`, `test-pages/`) was excluded from edits.
