### PR TITLE
🎨 Palette: Add role='status' to empty states for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -18,3 +18,6 @@ Critical UX/accessibility learnings only.
 ## 2026-05-18 - [Add visual and semantic loading states]
 **Learning:** Plain text loading indicators (like "Loading...") can feel unresponsive and lack proper semantic meaning for assistive technologies. Replacing them with an animated visual spinner and a `role="status"` wrapper ensures both sighted and screen-reader users understand the system is processing information.
 **Action:** Always use a visual indicator (like a spinner) accompanied by semantic `role="status"` and visually hidden text for asynchronous loading states.
+## 2026-06-25 - [Add `role="status"` to empty states for accessibility]
+**Learning:** When a list is filtered or searched and returns no results, the resulting "empty state" container is dynamically added to the page. Screen readers might not announce this change, leaving users confused. Adding `role="status"` to the empty state container ensures screen readers automatically announce the state change when it is dynamically rendered.
+**Action:** Always add `role="status"` to dynamically rendered empty state containers (e.g., "No articles found", "No upcoming events") to ensure the state change is announced to assistive technologies.

--- a/events.html
+++ b/events.html
@@ -413,7 +413,7 @@
                 if (!upcomingEventsContainer) return;
                 if (events.length === 0) {
                     upcomingEventsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                             </svg>
@@ -517,7 +517,7 @@
                 if (!pastEventsContainer) return;
                 if (events.length === 0) {
                     pastEventsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>

--- a/js/news.js
+++ b/js/news.js
@@ -270,7 +270,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function displayArticles(articles) {
         if (articles.length === 0) {
             articlesGrid.innerHTML = `
-                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>

--- a/test-pages/search.html
+++ b/test-pages/search.html
@@ -317,7 +317,7 @@
 
                 if (results.length === 0) {
                     resultsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                             </svg>


### PR DESCRIPTION
**💡 What**: Added `role="status"` to dynamically rendered empty state containers (e.g. "No articles found", "No upcoming events", etc.).

**🎯 Why**: When search or filter results return 0 items, the empty state UI is dynamically added to the DOM. Without `role="status"`, screen readers do not automatically announce this new message, leaving users who rely on assistive technologies confused as to why the results disappeared or what happened to their search.

**📸 Before/After**: N/A - This is a purely semantic, non-visual change.

**♿ Accessibility**: Explicitly ensures that screen readers will proactively announce dynamically rendered empty state messages to visually impaired users. This was also logged as a critical learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [8016873793405923001](https://jules.google.com/task/8016873793405923001) started by @jaxsnjohnson*