### PR TITLE
⚡ Bolt: optimize date parsing loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2026-05-18 - [Optimized Grouping via Substring]
+**Learning:** [To optimize operations on zero-padded ISO-8601 date strings, avoid instantiating `new Date()` inside loops. Extracting grouping keys via substring (e.g., `date.substring(0, 7)`) reduces date formatting operations from O(N) to O(1) per group. Likewise, extracting specific date components directly using substrings (e.g., `parseInt(date.substring(8, 10), 10)` for the day) avoids the overhead of calling methods on a Date object.]
+**Action:** [Use substring extraction for grouping and extracting date components when dates are guaranteed to be zero-padded ISO-8601 strings, falling back to `new Date()` parsing only for complex formatting.]

--- a/events.html
+++ b/events.html
@@ -533,17 +533,25 @@
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    // ⚡ Bolt: Extract grouping key via substring to avoid O(N) date parsing
+                    const groupKey = event.date.substring(0, 7);
+                    if (!acc[groupKey]) {
+                        // ⚡ Bolt: Parse date once per group for formatting
+                        const [year, month] = groupKey.split('-');
+                        const monthDate = new Date(year, parseInt(month, 10) - 1, 1);
+                        acc[groupKey] = {
+                            label: monthYearFormatter.format(monthDate),
+                            events: []
+                        };
+                    }
+                    acc[groupKey].events.push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
+                pastEventsContainer.innerHTML = Object.values(groupedByMonth).map(({ label: monthYear, events: monthEvents }) => {
                     const eventListItems = monthEvents.map(event => `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${parseInt(event.date.substring(8, 10), 10)}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
                     `).join('');


### PR DESCRIPTION
💡 What: Optimized `events.reduce()` grouping logic in `events.html` by parsing the ISO-8601 strings with `substring(0, 7)` to form group keys instead of instantiating `new Date()`. Additionally, extracted the day of the month directly via `substring(8, 10)` in the render loop instead of calling `getDate()`.

🎯 Why: Instantiating `new Date()` inside an `O(N)` loop is a severe performance bottleneck, especially when the required grouping and extraction keys can be reliably derived via fast `O(1)` string operations from a structured format (like ISO-8601).

📊 Impact: Reduces date instantiation and formatting operations from `O(N)` (per event) to `O(G)` (per month group), heavily accelerating large scale filtering and rendering loops.

🔬 Measurement: Check the rendering time or profile `events.reduce()` function when processing large numbers of upcoming/past events. The overall runtime for the script should drop, especially when rendering archive pages.

---
*PR created automatically by Jules for task [5734994857922569218](https://jules.google.com/task/5734994857922569218) started by @jaxsnjohnson*