### PR TITLE
🛡️ Sentinel: [security improvement] Add noreferrer to external target="_blank" links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@
 **Vulnerability:** User-controlled data (the `dateStr` derived from user clicks on calendar elements, stored in `dataset.date`) was interpolated directly into CSS selectors within `document.querySelector` calls in `events.html`'s `highlightEvent` function.
 **Learning:** Constructing CSS selectors using unescaped user input can lead to Selector Injection. This allows attackers to potentially inject arbitrary selectors or trigger Client-Side Denial of Service (DoS) by crafting complex inputs.
 **Prevention:** Always sanitize and escape user-controlled data using `CSS.escape()` before interpolating it into a CSS selector string.
+
+## 2026-06-08 - [Fix Reverse Tabnabbing Vulnerability]
+**Vulnerability:** Instances of target="_blank" were found missing the rel="noreferrer" attribute for external links, leaving the application susceptible to referral information leakage via the Referer header.
+**Learning:** Using target="_blank" for external cross-origin links without the rel="noreferrer" attribute causes the site to leak the referring page's URL to the external, potentially untrusted site.
+**Prevention:** Ensured rel="noopener noreferrer" is added to all user-facing external anchor tags that open in a new tab.

--- a/news/2026-05-07-economics-they-say-we-say.html
+++ b/news/2026-05-07-economics-they-say-we-say.html
@@ -204,7 +204,7 @@
                     <h2 class="text-2xl font-bold">Source note</h2>
                     <div class="article-content mt-3 text-base text-text-secondary space-y-3">
                         <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
-                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This page uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
+                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener noreferrer">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This page uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
                         <p>If this page and the contract PDF ever differ, the contract PDF is the source of truth. The <strong>Our union says</strong> and <strong>Why it matters</strong> sections below are our union's analysis.</p>
                     </div>
                 </div>

--- a/resources/corvallis-civic-action.html
+++ b/resources/corvallis-civic-action.html
@@ -199,8 +199,8 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Find Your Exact Representatives</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregonlegislature.gov/FindYourLegislator/leg-districts.html" target="_blank" rel="noopener">Oregon Legislature: Find Your Legislator</a></li>
-                    <li><a href="https://www.house.gov/representatives/find-your-representative" target="_blank" rel="noopener">U.S. House: Find Your Representative</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/FindYourLegislator/leg-districts.html" target="_blank" rel="noopener noreferrer">Oregon Legislature: Find Your Legislator</a></li>
+                    <li><a href="https://www.house.gov/representatives/find-your-representative" target="_blank" rel="noopener noreferrer">U.S. House: Find Your Representative</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Corvallis Area Contacts (Verified February 10, 2026)</h2>
@@ -208,22 +208,22 @@
                 <ul class="list-disc pl-5 space-y-2">
                     <li><strong>Mayor and City Council:</strong> <a href="mailto:mayorandcouncil@corvallisoregon.gov">mayorandcouncil@corvallisoregon.gov</a></li>
                     <li><strong>City Hall:</strong> coming soon</li>
-                    <li><a href="https://www.corvallisoregon.gov/mc/page/contact-city-council" target="_blank" rel="noopener">Official City Council Contact Page</a></li>
+                    <li><a href="https://www.corvallisoregon.gov/mc/page/contact-city-council" target="_blank" rel="noopener noreferrer">Official City Council Contact Page</a></li>
                 </ul>
 
                 <h3 class="text-2xl font-bold text-brand-purple-dark">Oregon Legislature</h3>
                 <ul class="list-disc pl-5 space-y-2">
                     <li><strong>Sen. Sara Gelser Blouin (District 8):</strong> coming soon, <a href="mailto:Sen.SaraGelser@oregonlegislature.gov">Sen.SaraGelser@oregonlegislature.gov</a></li>
                     <li><strong>Rep. Sarah Finger McDonald (District 16):</strong> coming soon, <a href="mailto:Rep.SarahFingerMcDonald@oregonlegislature.gov">Rep.SarahFingerMcDonald@oregonlegislature.gov</a></li>
-                    <li><a href="https://www.oregonlegislature.gov/gelser" target="_blank" rel="noopener">Sen. Gelser Blouin official page</a></li>
-                    <li><a href="https://www.oregonlegislature.gov/mcdonald" target="_blank" rel="noopener">Rep. Finger McDonald official page</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/gelser" target="_blank" rel="noopener noreferrer">Sen. Gelser Blouin official page</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/mcdonald" target="_blank" rel="noopener noreferrer">Rep. Finger McDonald official page</a></li>
                 </ul>
 
                 <h3 class="text-2xl font-bold text-brand-purple-dark">Federal (Oregon)</h3>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><strong>Sen. Ron Wyden:</strong> <a href="https://www.wyden.senate.gov/contact/email-ron" target="_blank" rel="noopener">Email form</a> | <a href="https://www.wyden.senate.gov/contact/office-locations" target="_blank" rel="noopener">Office locations</a></li>
-                    <li><strong>Sen. Jeff Merkley:</strong> <a href="https://www.merkley.senate.gov/connect/contact/" target="_blank" rel="noopener">Email form</a></li>
-                    <li><strong>Rep. Val Hoyle (OR-04):</strong> <a href="https://hoyle.house.gov/contact/email-val" target="_blank" rel="noopener">Email form</a></li>
+                    <li><strong>Sen. Ron Wyden:</strong> <a href="https://www.wyden.senate.gov/contact/email-ron" target="_blank" rel="noopener noreferrer">Email form</a> | <a href="https://www.wyden.senate.gov/contact/office-locations" target="_blank" rel="noopener noreferrer">Office locations</a></li>
+                    <li><strong>Sen. Jeff Merkley:</strong> <a href="https://www.merkley.senate.gov/connect/contact/" target="_blank" rel="noopener noreferrer">Email form</a></li>
+                    <li><strong>Rep. Val Hoyle (OR-04):</strong> <a href="https://hoyle.house.gov/contact/email-val" target="_blank" rel="noopener noreferrer">Email form</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">How to Write an Effective Message (60-120 Seconds to Read)</h2>

--- a/resources/elr-contacted-you-playbook.html
+++ b/resources/elr-contacted-you-playbook.html
@@ -267,7 +267,7 @@
                     <li><strong>Christopher Anderson</strong> - Employee Labor Relations Officer, coming soon</li>
                     <li><strong>Scott Southard</strong> - Senior Employee Labor Relations Officer (Classified employee bargaining matters), coming soon</li>
                 </ul>
-                <p>Source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener">OSU ELR Contact Directory</a></p>
+                <p>Source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener noreferrer">OSU ELR Contact Directory</a></p>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>
                 <ul class="list-disc pl-5 space-y-2">

--- a/resources/oregon-boli-rights.html
+++ b/resources/oregon-boli-rights.html
@@ -249,12 +249,12 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Official BOLI Links</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/your-rights-at-work.aspx" target="_blank" rel="noopener">Your Rights at Work</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/Pages/wage-and-hour-complaint-form.aspx" target="_blank" rel="noopener">Wage and Hour Complaint</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/paychecks.aspx" target="_blank" rel="noopener">Paycheck and Final Pay Rules</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/minimum-wage.aspx" target="_blank" rel="noopener">Minimum Wage Rates</a></li>
-                    <li><a href="https://www.oregon.gov/boli/civil-rights/pages/discrimination-at-work.aspx" target="_blank" rel="noopener">Discrimination at Work</a></li>
-                    <li><a href="https://www.oregon.gov/boli/workers/pages/retaliation-at-work.aspx" target="_blank" rel="noopener">Retaliation at Work</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/your-rights-at-work.aspx" target="_blank" rel="noopener noreferrer">Your Rights at Work</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/Pages/wage-and-hour-complaint-form.aspx" target="_blank" rel="noopener noreferrer">Wage and Hour Complaint</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/paychecks.aspx" target="_blank" rel="noopener noreferrer">Paycheck and Final Pay Rules</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/minimum-wage.aspx" target="_blank" rel="noopener noreferrer">Minimum Wage Rates</a></li>
+                    <li><a href="https://www.oregon.gov/boli/civil-rights/pages/discrimination-at-work.aspx" target="_blank" rel="noopener noreferrer">Discrimination at Work</a></li>
+                    <li><a href="https://www.oregon.gov/boli/workers/pages/retaliation-at-work.aspx" target="_blank" rel="noopener noreferrer">Retaliation at Work</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>

--- a/resources/oregon-elr-rights.html
+++ b/resources/oregon-elr-rights.html
@@ -213,8 +213,8 @@
                     <li><strong>Christopher Anderson</strong> - Employee Labor Relations Officer (Classified Employees, Professional Faculty), coming soon</li>
                     <li><strong>Scott Southard</strong> - Senior Employee Labor Relations Officer (Classified employee bargaining matters), coming soon</li>
                 </ul>
-                <p>Official directory source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener">OSU Employee and Labor Relations contact page</a></p>
-                <p>State public-sector labor relations context: <a href="https://www.oregon.gov/das/HR/Pages/LRU.aspx" target="_blank" rel="noopener">Oregon DAS Labor Relations Unit</a></p>
+                <p>Official directory source: <a href="https://hr.oregonstate.edu/contact-information-employee-and-labor-relations" target="_blank" rel="noopener noreferrer">OSU Employee and Labor Relations contact page</a></p>
+                <p>State public-sector labor relations context: <a href="https://www.oregon.gov/das/HR/Pages/LRU.aspx" target="_blank" rel="noopener noreferrer">Oregon DAS Labor Relations Unit</a></p>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">When to Contact Your Union First</h2>
                 <ul class="list-disc pl-5 space-y-3">

--- a/resources/oregon-erb-rights.html
+++ b/resources/oregon-erb-rights.html
@@ -248,11 +248,11 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Official Oregon ERB Links</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregon.gov/erb/Pages/AboutERB.aspx" target="_blank" rel="noopener">About ERB</a></li>
-                    <li><a href="https://www.oregon.gov/erb/Pages/PECBA.aspx" target="_blank" rel="noopener">PECBA Overview</a></li>
-                    <li><a href="https://www.oregon.gov/erb/Pages/ULP.aspx" target="_blank" rel="noopener">Unfair Labor Practice (ULP)</a></li>
-                    <li><a href="https://www.oregon.gov/erb/pages/forms.aspx" target="_blank" rel="noopener">ERB Forms</a></li>
-                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors243.html" target="_blank" rel="noopener">ORS Chapter 243 (PECBA and ERB statutes)</a></li>
+                    <li><a href="https://www.oregon.gov/erb/Pages/AboutERB.aspx" target="_blank" rel="noopener noreferrer">About ERB</a></li>
+                    <li><a href="https://www.oregon.gov/erb/Pages/PECBA.aspx" target="_blank" rel="noopener noreferrer">PECBA Overview</a></li>
+                    <li><a href="https://www.oregon.gov/erb/Pages/ULP.aspx" target="_blank" rel="noopener noreferrer">Unfair Labor Practice (ULP)</a></li>
+                    <li><a href="https://www.oregon.gov/erb/pages/forms.aspx" target="_blank" rel="noopener noreferrer">ERB Forms</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors243.html" target="_blank" rel="noopener noreferrer">ORS Chapter 243 (PECBA and ERB statutes)</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>

--- a/resources/ors-244-ethics-guide.html
+++ b/resources/ors-244-ethics-guide.html
@@ -246,10 +246,10 @@
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Official ORS 244 / OGEC Links</h2>
                 <ul class="list-disc pl-5 space-y-2">
-                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors244.html" target="_blank" rel="noopener">ORS 244 Full Text</a></li>
-                    <li><a href="https://www.oregon.gov/ogec/pages/laws.aspx" target="_blank" rel="noopener">OGEC Laws and Rules</a></li>
-                    <li><a href="https://www.oregon.gov/ogec/Pages/Guide-for-Public-Officials.aspx" target="_blank" rel="noopener">OGEC Guide for Public Officials</a></li>
-                    <li><a href="https://www.oregon.gov/ogec/Documents/Public%20Officials%20Guide/Guide_for_Public_Officials.pdf" target="_blank" rel="noopener">OGEC Public Officials Guide (PDF)</a></li>
+                    <li><a href="https://www.oregonlegislature.gov/bills_laws/ors/ors244.html" target="_blank" rel="noopener noreferrer">ORS 244 Full Text</a></li>
+                    <li><a href="https://www.oregon.gov/ogec/pages/laws.aspx" target="_blank" rel="noopener noreferrer">OGEC Laws and Rules</a></li>
+                    <li><a href="https://www.oregon.gov/ogec/Pages/Guide-for-Public-Officials.aspx" target="_blank" rel="noopener noreferrer">OGEC Guide for Public Officials</a></li>
+                    <li><a href="https://www.oregon.gov/ogec/Documents/Public%20Officials%20Guide/Guide_for_Public_Officials.pdf" target="_blank" rel="noopener noreferrer">OGEC Public Officials Guide (PDF)</a></li>
                 </ul>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark">Related Guides</h2>

--- a/test-pages/2026-03-30-31-management-says-we-say.html
+++ b/test-pages/2026-03-30-31-management-says-we-say.html
@@ -205,7 +205,7 @@
                     <h2 class="text-2xl font-bold">Source note for this draft</h2>
                     <div class="article-content mt-3 text-base text-text-secondary space-y-3">
                         <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
-                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This draft uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
+                        <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener noreferrer">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This draft uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
                         <p>If this page and the contract PDF ever differ, the contract PDF is the source of truth. The <strong>Our union says</strong> and <strong>Why it matters</strong> sections below are our union's analysis.</p>
                     </div>
                 </div>


### PR DESCRIPTION
🚨 **Severity**: MEDIUM/LOW (Security Enhancement)
💡 **Vulnerability**: Several external anchor tags using `target="_blank"` lacked the `rel="noreferrer"` attribute.
🎯 **Impact**: The application could leak the referring page's URL to external, potentially untrusted sites via the `Referer` header.
🔧 **Fix**: Added `rel="noopener noreferrer"` to all external links. Internal links were kept with `rel="noopener"` only to maintain correct analytics tracking.
✅ **Verification**: Verified using `git diff` that only external `target="_blank"` links were modified, and ran the site quality check and pytest suites to ensure no regressions were introduced. Also successfully passed code review avoiding any auto-generated python caches in version control.

---
*PR created automatically by Jules for task [13842848322655706659](https://jules.google.com/task/13842848322655706659) started by @jaxsnjohnson*