### PR TITLE
⚡ Bolt: Optimize date formatting in renderPastEvents

### DIFF
--- a/events.html
+++ b/events.html
@@ -532,21 +532,28 @@
                 // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
+                // ⚡ Bolt: Extract grouping keys via substring to reduce date formatting operations from O(N) to O(1) per group
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    const monthKey = event.date.substring(0, 7);
+                    if (!acc[monthKey]) acc[monthKey] = [];
+                    acc[monthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
-                    const eventListItems = monthEvents.map(event => `
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthKey, monthEvents]) => {
+                    const groupDate = new Date(monthKey.replace(/-/g, '/') + '/01');
+                    const monthYear = monthYearFormatter.format(groupDate);
+
+                    const eventListItems = monthEvents.map(event => {
+                        // ⚡ Bolt: Extract day directly using substring to avoid getDate() overhead on Date objects
+                        const day = parseInt(event.date.substring(8, 10), 10);
+                        return `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${day}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
-                    `).join('');
+                        `;
+                    }).join('');
 
                     return `
                         <details class="bg-white rounded-xl border border-border-color group transition-shadow duration-300 open:shadow-md">


### PR DESCRIPTION
💡 What:
Optimized the `renderPastEvents` rendering loop in `events.html`. Instead of allocating a `new Date()` and calling `.format()` on an `Intl.DateTimeFormat` instance for *every single item* (O(N)), the loop now extracts a `YYYY-MM` group key via string `substring`, groups items, and only performs date formatting once per month group (O(G)). It also extracts the exact day for rendering using `substring` and `parseInt()`, completely avoiding `new Date().getDate()`.

🎯 Why:
Instantiating `new Date()` and calling `toLocaleString()` inside loops causes performance overhead from massive object allocations, formatting, and DOM layout thrashing. Because dates are strictly formatted zero-padded ISO-8601 strings, we can rely entirely on strings to accomplish extraction tasks much faster.

📊 Impact:
Significantly reduces main-thread blocking time when rendering large numbers of archived events by dropping the expensive Date operations from O(N) to O(G), and avoids O(N) parsing inside the nested item map loops altogether. 

🔬 Measurement:
Start the local server `python3 -m http.server 8000` and visit `http://localhost:8000/events.html#past-events`. Expand the panels and verify that they load instantly and look visually identical (e.g. `18:` or `22:`) as before. Run `pytest tests/` and `python3 scripts/site_quality_check.py --strict-placeholders`.

---
*PR created automatically by Jules for task [6682851244234485167](https://jules.google.com/task/6682851244234485167) started by @jaxsnjohnson*