### PR TITLE
⚡ Bolt: Optimize date parsing in past events loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2024-05-18 - [RegExp Instantiation in Loops]
 **Learning:** [Instantiating `new RegExp()` inside rendering loops (like `Array.prototype.map()`) when the pattern is constant causes redundant pattern compilation and object creation on every iteration, harming performance. Furthermore, it's safe to hoist global RegExp instances (e.g., with the 'g' or 'gi' flag) outside of rendering loops and reuse them with `String.prototype.replace()`, because `replace()` automatically ignores and resets the regex's `lastIndex` property, preventing state leakage across loop iterations.]
 **Action:** [Always hoist `new RegExp()` instantiations outside the loop when the pattern (such as a search query) remains constant.]
+
+## 2024-05-20 - [Date Grouping Overhead]
+**Learning:** [Grouping an array of objects by month using `new Date()` and `Intl.DateTimeFormat` inside a reduce loop causes O(N) expensive parsing operations. Using `event.date.substring(0, 7)` directly on zero-padded ISO-8601 strings extracts the year-month key in O(1) time without parsing.]
+**Action:** [Use fast substring extraction to group data by month keys, and then run `new Date()` and `Intl.DateTimeFormat` only once per unique month key during rendering.]

--- a/events.html
+++ b/events.html
@@ -533,17 +533,19 @@
                 const monthYearFormatter = new Intl.DateTimeFormat('default', { month: 'long', year: 'numeric' });
 
                 const groupedByMonth = events.reduce((acc, event) => {
-                    event.parsedDate = new Date(event.date.replace(/-/g, '/'));
-                    const monthYear = monthYearFormatter.format(event.parsedDate);
-                    if (!acc[monthYear]) acc[monthYear] = [];
-                    acc[monthYear].push(event);
+                    const monthKey = event.date.substring(0, 7);
+                    if (!acc[monthKey]) acc[monthKey] = [];
+                    acc[monthKey].push(event);
                     return acc;
                 }, {});
 
-                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthYear, monthEvents]) => {
+                pastEventsContainer.innerHTML = Object.entries(groupedByMonth).map(([monthKey, monthEvents]) => {
+                    const groupDate = new Date(monthKey.replace(/-/g, '/') + '/01');
+                    const monthYear = monthYearFormatter.format(groupDate);
+
                     const eventListItems = monthEvents.map(event => `
                         <li class="py-2">
-                            <strong>${event.parsedDate.getDate()}:</strong> ${escapeHTML(event.title)}
+                            <strong>${parseInt(event.date.substring(8, 10), 10)}:</strong> ${escapeHTML(event.title)}
                             ${event.url !== '#' ? `<a href="${escapeHTML(sanitizeUrl(event.url))}" class="font-semibold text-brand-purple hover:underline ml-2" data-ph-event="event_click" data-ph-label="${escapeHTML(event.title)}" data-ph-metadata='{"section":"past"}'>View Details</a>` : ''}
                         </li>
                     `).join('');


### PR DESCRIPTION
💡 What: Optimized `renderPastEvents` to group past events by month using string substring instead of `new Date()`.
🎯 Why: `new Date()` and `Intl.DateTimeFormat` are computationally expensive operations, especially when executed inside mapping loops across arrays. Using substring extraction on zero-padded ISO-8601 strings reduces O(N) operations to O(1) operations per group. Also avoiding instantiating `Date` inside the loop for day extraction.
📊 Impact: Faster array grouping and array parsing.
🔬 Measurement: Run local performance benchmark on past events array.

---
*PR created automatically by Jules for task [15029547856087097081](https://jules.google.com/task/15029547856087097081) started by @jaxsnjohnson*