### PR TITLE
🎨 Palette: Add semantic role to empty UI states for screen readers

### DIFF
--- a/events.html
+++ b/events.html
@@ -413,7 +413,7 @@
                 if (!upcomingEventsContainer) return;
                 if (events.length === 0) {
                     upcomingEventsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                             </svg>
@@ -517,7 +517,7 @@
                 if (!pastEventsContainer) return;
                 if (events.length === 0) {
                     pastEventsContainer.innerHTML = `
-                        <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                        <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>

--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
                         }).join('');
                     } else {
                         eventsContainer.innerHTML = `
-                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                                 </svg>
@@ -694,7 +694,7 @@
                         `;
                     } else {
                         newsGridContainer.innerHTML = `
-                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed">
+                            <div class="col-span-full flex flex-col items-center justify-center py-12 px-6 bg-white rounded-xl border border-border-color border-dashed" role="status">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15M9 11l3 3m0 0l3-3m-3 3V8" />
                                 </svg>

--- a/js/news.js
+++ b/js/news.js
@@ -270,7 +270,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function displayArticles(articles) {
         if (articles.length === 0) {
             articlesGrid.innerHTML = `
-                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed">
+                <div class="col-span-full flex flex-col items-center justify-center py-16 bg-white rounded-xl border border-border-color border-dashed" role="status">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>


### PR DESCRIPTION
💡 **What**: Added `role="status"` to all empty state container divs that are dynamically injected when there are no events or news articles to display.
🎯 **Why**: When users apply filters or when no content is available (e.g., "No articles found"), the visual empty state is injected dynamically. Without an ARIA live region or status role, screen reader users are unaware of this update and may assume the page is broken or still loading.
♿ **Accessibility**: `role="status"` acts as an implicit `aria-live="polite"` region, meaning assistive technologies will announce the text content (e.g., "No upcoming events") to users naturally as it appears.

---
*PR created automatically by Jules for task [1252889560463681365](https://jules.google.com/task/1252889560463681365) started by @jaxsnjohnson*