### PR TITLE
Fix Spark mailto encoding

### DIFF
--- a/js/current-action.js
+++ b/js/current-action.js
@@ -54,10 +54,10 @@
     const mailtoFor = (emailAction, subject) => {
         const recipient = safeText(emailAction?.recipient);
         if (!recipient) return '#';
-        const params = new URLSearchParams();
-        if (subject) params.set('subject', subject);
-        if (emailAction?.body) params.set('body', emailAction.body);
-        return `mailto:${recipient}?${params.toString()}`;
+        const params = [];
+        if (subject) params.push(`subject=${encodeURIComponent(subject)}`);
+        if (emailAction?.body) params.push(`body=${encodeURIComponent(emailAction.body)}`);
+        return `mailto:${recipient}?${params.join('&')}`;
     };
 
     const configureEmailActions = (payload) => {


### PR DESCRIPTION
## Summary

- Replace form-style query serialization with percent encoding for the president-email `mailto:` URL.
- Preserve spaces and line breaks in Spark and other desktop mail clients instead of emitting literal `+` characters.

## Validation

- JavaScript syntax and diff checks
- Strict site quality check and unit tests
- Rendered homepage check confirmed `%20` spaces, `%0A` line breaks, no literal plus signs, and the expected decoded subject/body