### PR TITLE
Bust cached mailto action script

### DIFF
--- a/action/index.html
+++ b/action/index.html
@@ -124,7 +124,7 @@
 }
     </script>
     <script src="/js/analytics.js" defer></script>
-    <script src="/js/current-action.js?v=2026-07-09-email-hotfix" defer></script>
+    <script src="/js/current-action.js?v=2026-07-09-email-encoding-hotfix" defer></script>
 </head>
 <body class="bg-brand-light">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:text-brand-purple-dark focus:px-4 focus:py-2 focus:rounded focus:shadow-lg">Skip to content</a>

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
     </script>
     <!-- SEO META END -->
     <script src="/js/analytics.js" defer></script>
-    <script src="/js/current-action.js?v=2026-07-09-email-hotfix" defer></script>
+    <script src="/js/current-action.js?v=2026-07-09-email-encoding-hotfix" defer></script>
 </head>
 <body class="bg-brand-light">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:text-brand-purple-dark focus:px-4 focus:py-2 focus:rounded focus:shadow-lg">Skip to content</a>

--- a/js/current-action.js
+++ b/js/current-action.js
@@ -1,5 +1,5 @@
 (function () {
-    const DATA_URL = '/data/current-action.json?v=2026-07-09-email-hotfix';
+    const DATA_URL = '/data/current-action.json?v=2026-07-09-email-encoding-hotfix';
 
     const safeText = (value) => String(value || '');
 

--- a/news/2026-07-09-latest-bargaining-update.html
+++ b/news/2026-07-09-latest-bargaining-update.html
@@ -182,7 +182,7 @@
 }
     </script>
     <script src="/js/analytics.js" defer></script>
-    <script src="/js/current-action.js?v=2026-07-09-email-hotfix" defer></script>
+    <script src="/js/current-action.js?v=2026-07-09-email-encoding-hotfix" defer></script>
 </head>
 <body class="bg-brand-light">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:text-brand-purple-dark focus:px-4 focus:py-2 focus:rounded focus:shadow-lg">Skip to content</a>

--- a/news/2026-07-09-tell-universities-hell-no.html
+++ b/news/2026-07-09-tell-universities-hell-no.html
@@ -181,7 +181,7 @@
 }
     </script>
     <script src="/js/analytics.js" defer></script>
-    <script src="/js/current-action.js?v=2026-07-09-email-hotfix" defer></script>
+    <script src="/js/current-action.js?v=2026-07-09-email-encoding-hotfix" defer></script>
 </head>
 <body class="bg-brand-light">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:text-brand-purple-dark focus:px-4 focus:py-2 focus:rounded focus:shadow-lg">Skip to content</a>


### PR DESCRIPTION
## Summary

- Bump the current-action JavaScript cache-buster everywhere the president-email CTA appears.
- Bump the action-data fetch version as well, ensuring deployed clients retrieve the percent-encoding fix instead of stale JavaScript.

## Root Cause

The encoding correction had already merged, but the script URL remained `?v=2026-07-09-email-hotfix`. Cached clients could continue running the previous `URLSearchParams` implementation, which emitted literal plus signs in Spark.

## Validation

- Fresh local server on a clean port
- All four public CTA entry points tested
- Confirmed `%20` spaces, `%0A` line breaks, no literal `+` characters, and decoded subject/body values
- Strict site quality check, unit tests, JavaScript syntax checks, and diff validation