### PR TITLE
Standardize membership reminder times

### DIFF
--- a/marketing/email/2026-04-15-Membership-Meeting-Reminder.html
+++ b/marketing/email/2026-04-15-Membership-Meeting-Reminder.html
@@ -14,7 +14,7 @@
 </head>
 <body style="background-color: #F9FAFB; margin: 0; padding: 0; width: 100%; -webkit-font-smoothing: antialiased;">
     <div style="display: none; max-height: 0; overflow: hidden; opacity: 0; mso-hide: all; line-height: 1px; font-size: 1px;">
-        Join us tomorrow from 12 to 1 p.m. for important bargaining updates with SEIU 503 President Johnny Earl.
+        Join us tomorrow from noon to 1 p.m. for important bargaining updates with SEIU 503 President Johnny Earl.
     </div>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #F9FAFB;">
         <tr>
@@ -24,14 +24,14 @@
                         <td style="background-color: #EDE9FE; padding: 36px 30px; text-align: center; border-bottom: 1px solid #D1D5DB; border-top-left-radius: 16px; border-top-right-radius: 16px;">
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 12px 0; color: #4C1D95; font-size: 13px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;">SEIU Local 503 at Oregon State University</p>
                             <h1 style="font-family: 'Lora', Georgia, serif; font-size: 32px; margin: 0 0 10px 0; color: #4C1D95;">Membership Meeting Is Tomorrow</h1>
-                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 6px 0; font-size: 18px; color: #4C1D95; line-height: 1.5; font-weight: 700;">Thursday, April 16, 2026 • 12 to 1 p.m.</p>
+                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 6px 0; font-size: 18px; color: #4C1D95; line-height: 1.5; font-weight: 700;">Thursday, April 16, 2026 • noon to 1 p.m.</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0; font-size: 17px; color: #4C1D95; line-height: 1.5;">MU 211 or Zoom</p>
                         </td>
                     </tr>
                     <tr>
                         <td style="padding: 40px 30px;">
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">Hi everyone,</p>
-                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">Please join us <strong>tomorrow, Thursday, April 16, 2026</strong>, from <strong>12 to 1 p.m.</strong> for our membership meeting in <strong>MU 211</strong> or on <strong>Zoom</strong>.</p>
+                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">Please join us <strong>tomorrow, Thursday, April 16, 2026</strong>, from <strong>noon to 1 p.m.</strong> for our membership meeting in <strong>MU 211</strong> or on <strong>Zoom</strong>.</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;"><strong>SEIU 503 President Johnny Earl will be with us</strong>, and we will be talking about our new leadership, where bargaining has been, and where bargaining is headed next.</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 8px 0; color: #1F2937; font-size: 16px; line-height: 1.6; font-weight: 700;">What we'll cover</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 24px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">New leadership, past and future bargaining, and other important contract campaign updates members need to hear directly.</p>
@@ -59,7 +59,7 @@
                                 <tr>
                                     <td style="padding: 14px 20px; border-top: 1px solid #E5E7EB;">
                                         <p style="margin: 0 0 4px 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 12px; letter-spacing: 0.05em; text-transform: uppercase; font-weight: 700; color: #6B7280;">Time</p>
-                                        <p style="margin: 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; color: #1F2937; line-height: 1.5;">12 to 1 p.m.</p>
+                                        <p style="margin: 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; color: #1F2937; line-height: 1.5;">Noon to 1 p.m.</p>
                                     </td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `marketing/email/2026-04-15-Membership-Meeting-Reminder.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings