### PR TITLE
Fix CAT reminder time and steward CTA

### DIFF
--- a/marketing/email/2026-04-27-CAT-Meeting-Reminder.html
+++ b/marketing/email/2026-04-27-CAT-Meeting-Reminder.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Mailchimp subject: Reminder: CAT Meeting Today at Noon -->
-    <!-- Mailchimp preview text: CAT members: join us today from 12 to 1 p.m. on Zoom for table updates and field next steps. -->
+    <!-- Mailchimp preview text: CAT members: join us today from noon to 1 p.m. on Zoom for table updates and field next steps. -->
     <title>Reminder: CAT Meeting Today at Noon</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Lora:wght@700&display=swap" rel="stylesheet">
     <style>
@@ -16,7 +16,7 @@
 </head>
 <body style="background-color: #F9FAFB; margin: 0; padding: 0; width: 100%; -webkit-font-smoothing: antialiased;">
     <div style="display: none; max-height: 0; overflow: hidden; opacity: 0; mso-hide: all; line-height: 1px; font-size: 1px;">
-        CAT members: join us today from 12 to 1 p.m. on Zoom for table updates and field next steps.
+        CAT members: join us today from noon to 1 p.m. on Zoom for table updates and field next steps.
     </div>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #F9FAFB;">
         <tr>
@@ -26,14 +26,14 @@
                         <td style="background-color: #EDE9FE; padding: 36px 30px; text-align: center; border-bottom: 1px solid #D1D5DB; border-top-left-radius: 16px; border-top-right-radius: 16px;">
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 12px 0; color: #4C1D95; font-size: 13px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;">SEIU Local 503 at Oregon State University</p>
                             <h1 style="font-family: 'Lora', Georgia, serif; font-size: 32px; margin: 0 0 10px 0; color: #4C1D95;">CAT Meeting Today at Noon</h1>
-                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 6px 0; font-size: 18px; color: #4C1D95; line-height: 1.5; font-weight: 700;">Monday, April 27, 2026 &bull; 12 to 1 p.m.</p>
+                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 6px 0; font-size: 18px; color: #4C1D95; line-height: 1.5; font-weight: 700;">Monday, April 27, 2026 &bull; noon to 1 p.m.</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0; font-size: 17px; color: #4C1D95; line-height: 1.5;">Zoom</p>
                         </td>
                     </tr>
                     <tr>
                         <td style="padding: 40px 30px;">
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">Hi CAT,</p>
-                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">This is a reminder that our CAT meeting is <strong>today, Monday, April 27, from 12 to 1 p.m. Pacific</strong> on Zoom.</p>
+                            <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">This is a reminder that our CAT meeting is <strong>today, Monday, April 27, from noon to 1 p.m. Pacific</strong> on Zoom.</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 16px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">We will review the latest updates from our bargaining team, answer questions, and talk through next steps in the field.</p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; margin: 0 0 24px 0; color: #1F2937; font-size: 16px; line-height: 1.6;">Please make time to join so CAT members can move information clearly and quickly to members across OSU.</p>
 
@@ -60,7 +60,7 @@
                                 <tr>
                                     <td style="padding: 14px 20px; border-top: 1px solid #E5E7EB;">
                                         <p style="margin: 0 0 4px 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 12px; letter-spacing: 0.05em; text-transform: uppercase; font-weight: 700; color: #6B7280;">Time</p>
-                                        <p style="margin: 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; color: #1F2937; line-height: 1.5;">12 to 1 p.m. Pacific Time</p>
+                                        <p style="margin: 0; font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 16px; color: #1F2937; line-height: 1.5;">Noon to 1 p.m. Pacific time</p>
                                     </td>
                                 </tr>
                                 <tr>
@@ -94,8 +94,7 @@
                     <tr>
                         <td style="background-color: #F9FAFB; padding: 24px 30px; text-align: center; border-top: 1px solid #D1D5DB; border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;">
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 12px; color: #6B7280; margin: 0 0 12px 0; line-height: 1.6;">
-                                Need a steward? <a href="mailto:083stewards@seiu503.org" style="color: #6D28D9; text-decoration: underline;">Click here</a> or email:
-                                <a href="mailto:083stewards@seiu503.org" style="color: #6D28D9; text-decoration: underline;">083stewards@seiu503.org</a>
+                                Need a steward? Email <a href="mailto:083stewards@seiu503.org" style="color: #6D28D9; text-decoration: underline;">083stewards@seiu503.org</a>.
                             </p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 12px; color: #6B7280; margin: 0; line-height: 1.6;">
                                 You are receiving this email because you are on our union announcement list.<br><br>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `marketing/email/2026-04-27-CAT-Meeting-Reminder.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings