### PR TITLE
Make membership reminder steward CTA descriptive

### DIFF
--- a/marketing/email/2026-05-20-Membership-Meeting-Reminder.html
+++ b/marketing/email/2026-05-20-Membership-Meeting-Reminder.html
@@ -134,8 +134,7 @@
                     <tr>
                         <td style="background-color: #F9FAFB; padding: 24px 30px; text-align: center; border-top: 1px solid #D1D5DB; border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;">
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 12px; color: #6B7280; margin: 0 0 12px 0; line-height: 1.6;">
-                                Need a steward? <a href="mailto:083stewards@seiu503.org" style="color: #6D28D9; text-decoration: underline;">Click here</a> or email:
-                                <a href="mailto:083stewards@seiu503.org" style="color: #6D28D9; text-decoration: underline;">083stewards@seiu503.org</a>
+                                Need a steward? Email <a href="mailto:083stewards@seiu503.org" style="color: #6D28D9; text-decoration: underline;">083stewards@seiu503.org</a>.
                             </p>
                             <p style="font-family: 'Inter', Helvetica, Arial, sans-serif; font-size: 12px; color: #6B7280; margin: 0; line-height: 1.6;">
                                 You are receiving this email because you are on our union announcement list.<br><br>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `marketing/email/2026-05-20-Membership-Meeting-Reminder.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings