### PR TITLE
Correct October CAT meeting nomenclature

### DIFF
--- a/events/2025-10-22-CAT-Meeting.html
+++ b/events/2025-10-22-CAT-Meeting.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.">
+    <meta name="description" content="Our Local 083 Contract Action Team met to share bargaining updates and plan coworker communication across OSU campuses.">
     <meta name="author" content="SEIU Local 503 at OSU">
     <title>Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU</title>
     <style>html{visibility:hidden;}html.tw-ready{visibility:visible;}</style>
@@ -85,13 +85,13 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.local083.org/events/2025-10-22-CAT-Meeting.html">
     <meta property="og:title" content="Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU">
-    <meta property="og:description" content="Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.">
+    <meta property="og:description" content="Our Local 083 Contract Action Team met to share bargaining updates and plan coworker communication across OSU campuses.">
     <meta property="og:image" content="https://www.local083.org/images/card.webp">
     <meta property="og:site_name" content="SEIU Local 503 at Oregon State University">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://www.local083.org/events/2025-10-22-CAT-Meeting.html">
     <meta name="twitter:title" content="Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU">
-    <meta name="twitter:description" content="Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.">
+    <meta name="twitter:description" content="Our Local 083 Contract Action Team met to share bargaining updates and plan coworker communication across OSU campuses.">
     <meta name="twitter:image" content="https://www.local083.org/images/card.webp">
     <script type="application/ld+json">
 {
@@ -118,7 +118,7 @@
       "@id": "https://www.local083.org/events/2025-10-22-CAT-Meeting.html#webpage",
       "url": "https://www.local083.org/events/2025-10-22-CAT-Meeting.html",
       "name": "Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU",
-      "description": "Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.",
+      "description": "Our Local 083 Contract Action Team met to share bargaining updates and plan coworker communication across OSU campuses.",
       "isPartOf": {
         "@id": "https://www.local083.org#website"
       },
@@ -129,8 +129,8 @@
     {
       "@type": "Event",
       "@id": "https://www.local083.org/events/2025-10-22-CAT-Meeting.html#event",
-      "name": "Contact Action Team (CAT) Meeting",
-      "description": "Our SEIU Local 083 Contact Action Team meeting is tomorrow (Wednesday, Oct 22) from 12:00–1:00 PM on Zoom. We’ll be talking about what’s happening in bargaining and how we can communicate with coworkers across all campuses to support our bargaining team.",
+      "name": "Contract Action Team (CAT) Meeting",
+      "description": "Our SEIU Local 083 Contract Action Team met on Zoom from noon to 1 p.m. Wednesday, Oct. 22. We discussed bargaining and how to communicate with coworkers across all campuses in support of our bargaining team.",
       "startDate": "2025-10-22",
       "url": "https://www.local083.org/events/2025-10-22-CAT-Meeting.html",
       "eventStatus": "https://schema.org/EventScheduled",
@@ -184,7 +184,7 @@
     <section class="bg-brand-purple-light border-b border-border-color">
         <div class="container mx-auto px-6 py-16 text-center">
             <p class="text-brand-purple font-bold mb-2">Wednesday, October 22, 2025</p>
-            <h1 class="text-5xl font-bold">Contact Action Team (CAT) Meeting</h1>
+            <h1 class="text-5xl font-bold">Contract Action Team (CAT) Meeting</h1>
             <p class="mt-4 text-lg text-text-secondary max-w-3xl mx-auto">Join us to help organize and mobilize our coworkers for a strong contract!</p>
         </div>
     </section>
@@ -196,8 +196,8 @@
             <div class="lg:col-span-2 bg-white p-8 md:p-12 rounded-xl border border-border-color">
                 <h2 class="text-3xl font-bold mb-6">About this Event</h2>
                 <div class="prose max-w-none text-text-secondary text-lg leading-relaxed">
-                    <p>Our SEIU Local 083 Contact Action Team meeting is tomorrow (Wednesday, Oct 22) from 12:00–1:00 PM on Zoom.</p>
-                    <p>We’ll be talking about what’s happening in bargaining and how we can communicate with coworkers across all campuses to support our bargaining team.</p>
+                    <p>Our SEIU Local 083 Contract Action Team met on Zoom from noon to 1 p.m. Wednesday, Oct. 22.</p>
+                    <p>We discussed bargaining and how to communicate with coworkers across all campuses in support of our bargaining team.</p>
 
                     <h3 class="text-2xl font-bold mt-8 mb-4 text-brand-purple-dark">Agenda / What to Expect</h3>
                     <ul class="list-disc pl-5 space-y-2">

--- a/events/events.json
+++ b/events/events.json
@@ -2,8 +2,8 @@
   {
     "date": "2025-10-22",
     "time": "12:00 PM - 1:00 PM",
-    "title": "Contact Action Team (CAT) Meeting",
-    "description": "Our SEIU Local 083 Contact Action Team meeting ran on Zoom from 12:00–1:00 PM. We discussed what was happening in bargaining and how we communicated with coworkers across all campuses to support our bargaining team.",
+    "title": "Contract Action Team (CAT) Meeting",
+    "description": "Our SEIU Local 083 Contract Action Team met on Zoom from noon to 1 p.m. We discussed bargaining and how to communicate with coworkers across all campuses in support of our bargaining team.",
     "type": "Zoom Meeting",
     "url": "/events/2025-10-22-CAT-Meeting.html",
     "featured": true,

--- a/events/rss.xml
+++ b/events/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Upcoming events from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:29 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/events/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>CAT Meeting</title>
@@ -120,10 +120,10 @@
       <category>Zoom Meeting</category>
     </item>
     <item>
-      <title>Contact Action Team (CAT) Meeting</title>
+      <title>Contract Action Team (CAT) Meeting</title>
       <link>https://www.local083.org/events/2025-10-22-CAT-Meeting.html</link>
-      <guid isPermaLink="false">event:2025-10-22:Contact Action Team (CAT) Meeting</guid>
-      <description>Our SEIU Local 083 Contact Action Team meeting ran on Zoom from 12:00–1:00 PM. We discussed what was happening in bargaining and how we communicated with coworkers across all campuses to support our bargaining team. | Date: 2025-10-22 | Time: 12:00 PM - 1:00 PM | Location: Online via Zoom</description>
+      <guid isPermaLink="false">event:2025-10-22:Contract Action Team (CAT) Meeting</guid>
+      <description>Our SEIU Local 083 Contract Action Team met on Zoom from noon to 1 p.m. We discussed bargaining and how to communicate with coworkers across all campuses in support of our bargaining team. | Date: 2025-10-22 | Time: 12:00 PM - 1:00 PM | Location: Online via Zoom</description>
       <pubDate>Wed, 22 Oct 2025 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Combined news and event updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:29 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Event] CAT Meeting</title>
@@ -430,10 +430,10 @@
       <category>Social Event</category>
     </item>
     <item>
-      <title>[Event] Contact Action Team (CAT) Meeting</title>
+      <title>[Event] Contract Action Team (CAT) Meeting</title>
       <link>https://www.local083.org/events/2025-10-22-CAT-Meeting.html</link>
-      <guid isPermaLink="false">event:2025-10-22:Contact Action Team (CAT) Meeting:combined</guid>
-      <description>Our SEIU Local 083 Contact Action Team meeting ran on Zoom from 12:00–1:00 PM. We discussed what was happening in bargaining and how we communicated with coworkers across all campuses to support our bargaining team. | Date: 2025-10-22 | Time: 12:00 PM - 1:00 PM | Location: Online via Zoom</description>
+      <guid isPermaLink="false">event:2025-10-22:Contract Action Team (CAT) Meeting:combined</guid>
+      <description>Our SEIU Local 083 Contract Action Team met on Zoom from noon to 1 p.m. We discussed bargaining and how to communicate with coworkers across all campuses in support of our bargaining team. | Date: 2025-10-22 | Time: 12:00 PM - 1:00 PM | Location: Online via Zoom</description>
       <pubDate>Wed, 22 Oct 2025 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/news/rss.xml
+++ b/news/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>News and updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:29 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/news/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Our union bargaining update: 0% COLAs and a 19-year step path</title>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `events/2025-10-22-CAT-Meeting.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings