### PR TITLE
Clarify CAT meeting redirect link

### DIFF
--- a/events/2026-02-04-CAT-Meeting.html
+++ b/events/2026-02-04-CAT-Meeting.html
@@ -81,7 +81,7 @@
         <h1 class="text-3xl font-bold text-gray-800 mb-4">This event has been rescheduled.</h1>
         <p class="text-gray-600">You are being automatically redirected to the new page.</p>
         <p class="mt-4 text-sm text-gray-500">
-            If you are not redirected, <a href="/events/2026-02-05-CAT-Meeting.html" class="text-purple-600 hover:underline">please click here</a>.
+            If you are not redirected, <a href="/events/2026-02-05-CAT-Meeting.html" class="text-purple-600 hover:underline">view the Feb. 5 CAT Meeting</a>.
         </p>
     </div>
 </body>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `events/2026-02-04-CAT-Meeting.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings