### PR TITLE
Correct March CAT meeting copy

### DIFF
--- a/events/2026-03-10-CAT-Meeting.html
+++ b/events/2026-03-10-CAT-Meeting.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.">
+    <meta name="description" content="Details for the SEIU Local 083 Contract Action Team (CAT) meeting at Oregon State University.">
     <meta name="author" content="SEIU Local 503 at OSU">
     <title>Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU</title>
     <style>html{visibility:hidden;}html.tw-ready{visibility:visible;}</style>
@@ -85,13 +85,13 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.local083.org/events/2026-03-10-CAT-Meeting.html">
     <meta property="og:title" content="Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU">
-    <meta property="og:description" content="Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.">
+    <meta property="og:description" content="Details for the SEIU Local 083 Contract Action Team (CAT) meeting at Oregon State University.">
     <meta property="og:image" content="https://www.local083.org/images/card.webp">
     <meta property="og:site_name" content="SEIU Local 503 at Oregon State University">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://www.local083.org/events/2026-03-10-CAT-Meeting.html">
     <meta name="twitter:title" content="Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU">
-    <meta name="twitter:description" content="Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.">
+    <meta name="twitter:description" content="Details for the SEIU Local 083 Contract Action Team (CAT) meeting at Oregon State University.">
     <meta name="twitter:image" content="https://www.local083.org/images/card.webp">
     <script type="application/ld+json">
 {
@@ -118,7 +118,7 @@
       "@id": "https://www.local083.org/events/2026-03-10-CAT-Meeting.html#webpage",
       "url": "https://www.local083.org/events/2026-03-10-CAT-Meeting.html",
       "name": "Event: Contract Action Team (CAT) Meeting - SEIU Local 503, OSU",
-      "description": "Details for the upcoming SEIU Local 083 Contact Action Team (CAT) Meeting at Oregon State University.",
+      "description": "Details for the SEIU Local 083 Contract Action Team (CAT) meeting at Oregon State University.",
       "isPartOf": {
         "@id": "https://www.local083.org#website"
       },
@@ -130,7 +130,7 @@
       "@type": "Event",
       "@id": "https://www.local083.org/events/2026-03-10-CAT-Meeting.html#event",
       "name": "CAT Meeting",
-      "description": "Come to our Contact Action Team Meeting to get information to spread in your area!",
+      "description": "Join our Contract Action Team meeting for bargaining updates and information to share with coworkers in your work area.",
       "startDate": "2026-03-10",
       "url": "https://www.local083.org/events/2026-03-10-CAT-Meeting.html",
       "eventStatus": "https://schema.org/EventScheduled",
@@ -196,13 +196,13 @@
             <div class="lg:col-span-2 bg-white p-8 md:p-12 rounded-xl border border-border-color">
                 <h2 class="text-3xl font-bold mb-6">About this Event</h2>
                 <div class="prose max-w-none text-text-secondary text-lg leading-relaxed">
-                    <p>Contract Action Team (CAT) members organize their co-workers to get involved in the fight for a good contract and to help identify and organize around issues at work. This means sharing information with co-workers and with other worksite union leaders. CATs often play a key role in informing and mobilizing members. The more members who get involved, the better!</p>
+                    <p>Contract Action Team (CAT) members organize their coworkers to get involved in the fight for a good contract and to help identify and organize around issues at work. This means sharing information with coworkers and with other worksite union leaders. CATs often play a key role in informing and mobilizing members. The more members who get involved, the better!</p>
 
                     <h3 class="text-2xl font-bold mt-8 mb-4 text-brand-purple-dark">Agenda:</h3>
                     <ul class="list-disc pl-5 space-y-2">
                         <li>Bargaining Conference</li>
                         <li>Bargaining Questions & Ideas</li>
-                        <li>The Plan and what CAT’s do</li>
+                        <li>The plan and what CATs do</li>
                     </ul>
                     <h3 class="text-2xl font-bold !mt-10 !mb-4 text-brand-purple-dark">Elections & Requirements</h3>
                     <p>CAT members are not elected, but rather volunteer to get more involved. Contact your organizer for more information and to learn how to get involved.</p>

--- a/events/events.json
+++ b/events/events.json
@@ -270,7 +270,7 @@
     "date": "2026-03-10",
     "time": "7:00 PM - 8:00 PM",
     "title": "CAT Meeting",
-    "description": "Come to our Contact Action Team Meeting to get information to spread in your area!",
+    "description": "Join our Contract Action Team meeting for bargaining updates and information to share with coworkers in your work area.",
     "type": "Zoom Meeting",
     "url": "/events/2026-03-10-CAT-Meeting.html",
     "featured": false,

--- a/events/rss.xml
+++ b/events/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Upcoming events from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:19 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/events/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>CAT Meeting</title>
@@ -291,7 +291,7 @@
       <title>CAT Meeting</title>
       <link>https://www.local083.org/events/2026-03-10-CAT-Meeting.html</link>
       <guid isPermaLink="false">event:2026-03-10:CAT Meeting</guid>
-      <description>Come to our Contact Action Team Meeting to get information to spread in your area! | Date: 2026-03-10 | Time: 7:00 PM - 8:00 PM | Location: Online via Zoom</description>
+      <description>Join our Contract Action Team meeting for bargaining updates and information to share with coworkers in your work area. | Date: 2026-03-10 | Time: 7:00 PM - 8:00 PM | Location: Online via Zoom</description>
       <pubDate>Tue, 10 Mar 2026 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Combined news and event updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:19 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Event] CAT Meeting</title>
@@ -202,7 +202,7 @@
       <title>[Event] CAT Meeting</title>
       <link>https://www.local083.org/events/2026-03-10-CAT-Meeting.html</link>
       <guid isPermaLink="false">event:2026-03-10:CAT Meeting:combined</guid>
-      <description>Come to our Contact Action Team Meeting to get information to spread in your area! | Date: 2026-03-10 | Time: 7:00 PM - 8:00 PM | Location: Online via Zoom</description>
+      <description>Join our Contract Action Team meeting for bargaining updates and information to share with coworkers in your work area. | Date: 2026-03-10 | Time: 7:00 PM - 8:00 PM | Location: Online via Zoom</description>
       <pubDate>Tue, 10 Mar 2026 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/news/rss.xml
+++ b/news/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>News and updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:19 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/news/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Our union bargaining update: 0% COLAs and a 19-year step path</title>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `events/2026-03-10-CAT-Meeting.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings