### PR TITLE
Add confirmed membership meeting end time

### DIFF
--- a/events/2026-06-18-OSU-June-Membership-Meeting.html
+++ b/events/2026-06-18-OSU-June-Membership-Meeting.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Join SEIU Local 083 for the OSU June Membership Meeting on Zoom at noon Pacific time on June 18, 2026, with bargaining updates, layoff rights, and June 30 rally prep.">
+    <meta name="description" content="Join SEIU Local 083 for the OSU June Membership Meeting on Zoom from noon to 1 p.m. Pacific time, with bargaining updates and rally prep.">
     <meta name="author" content="SEIU Local 503 at OSU">
     <title>Event: OSU June Membership Meeting - SEIU Local 503, OSU</title>
     <style>html{visibility:hidden;}html.tw-ready{visibility:visible;}</style>
@@ -116,6 +116,7 @@
       "name": "OSU June Membership Meeting",
       "description": "SEIU Local 083 membership meeting on Zoom with bargaining updates, layoff rights, and June 30 rally prep.",
       "startDate": "2026-06-18T12:00:00-07:00",
+      "endDate": "2026-06-18T13:00:00-07:00",
       "eventStatus": "https://schema.org/EventScheduled",
       "location": {
         "@type": "VirtualLocation",
@@ -179,7 +180,7 @@
             <div class="lg:col-span-2 bg-white p-8 md:p-12 rounded-xl border border-border-color">
                 <h2 class="text-3xl font-bold mb-6">About this Event</h2>
                 <div class="prose max-w-none text-text-secondary text-lg leading-relaxed space-y-6">
-                    <p>Please join SEIU Local 083 for the OSU June Membership Meeting on Thursday, June 18, 2026, at 12:00 PM Pacific time.</p>
+                    <p>Please join SEIU Local 083 for the OSU June Membership Meeting from noon to 1 p.m. Pacific time Thursday, June 18, 2026.</p>
                     <p>This meeting is focused on what members can do before the June 30 rally. We will connect bargaining, layoff rights, our new office, and legislative outreach to one goal: a strong turnout that shows OSU workers are organized for a fair contract.</p>
 
                     <h3 class="text-2xl font-bold !mt-10 !mb-4 text-brand-purple-dark">High-Level Agenda</h3>
@@ -200,7 +201,7 @@
                     <div class="space-y-5 text-lg">
                         <div>
                             <h4 class="font-bold">Date & Time</h4>
-                            <p class="text-text-secondary">Thursday, June 18, 2026<br>12:00 PM Pacific Time</p>
+                            <p class="text-text-secondary">Thursday, June 18, 2026<br>Noon-1 p.m. Pacific time</p>
                         </div>
                         <div>
                             <h4 class="font-bold">Location</h4>

--- a/events/events.json
+++ b/events/events.json
@@ -53,9 +53,9 @@
   },
   {
     "date": "2026-06-18",
-    "time": "12:00 PM PT",
+    "time": "12:00 PM - 1:00 PM PT",
     "title": "OSU June Membership Meeting",
-    "description": "Join SEIU Local 083 for the OSU June membership meeting on Zoom at noon Pacific time.",
+    "description": "Join SEIU Local 083 for the OSU June membership meeting on Zoom from noon to 1 p.m. Pacific time.",
     "type": "Zoom Meeting",
     "url": "/events/2026-06-18-OSU-June-Membership-Meeting.html",
     "featured": false,

--- a/events/rss.xml
+++ b/events/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Upcoming events from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:06 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/events/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>CAT Meeting</title>
@@ -395,7 +395,7 @@
       <title>OSU June Membership Meeting</title>
       <link>https://www.local083.org/events/2026-06-18-OSU-June-Membership-Meeting.html</link>
       <guid isPermaLink="false">event:2026-06-18:OSU June Membership Meeting</guid>
-      <description>Join SEIU Local 083 for the OSU June membership meeting on Zoom at noon Pacific time. | Date: 2026-06-18 | Time: 12:00 PM PT | Location: Online via Zoom</description>
+      <description>Join SEIU Local 083 for the OSU June membership meeting on Zoom from noon to 1 p.m. Pacific time. | Date: 2026-06-18 | Time: 12:00 PM - 1:00 PM PT | Location: Online via Zoom</description>
       <pubDate>Thu, 18 Jun 2026 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Combined news and event updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:06 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Event] CAT Meeting</title>
@@ -71,7 +71,7 @@
       <title>[Event] OSU June Membership Meeting</title>
       <link>https://www.local083.org/events/2026-06-18-OSU-June-Membership-Meeting.html</link>
       <guid isPermaLink="false">event:2026-06-18:OSU June Membership Meeting:combined</guid>
-      <description>Join SEIU Local 083 for the OSU June membership meeting on Zoom at noon Pacific time. | Date: 2026-06-18 | Time: 12:00 PM PT | Location: Online via Zoom</description>
+      <description>Join SEIU Local 083 for the OSU June membership meeting on Zoom from noon to 1 p.m. Pacific time. | Date: 2026-06-18 | Time: 12:00 PM - 1:00 PM PT | Location: Online via Zoom</description>
       <pubDate>Thu, 18 Jun 2026 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/news/rss.xml
+++ b/news/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>News and updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:06 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/news/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Our union bargaining update: 0% COLAs and a 19-year step path</title>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `events/2026-06-18-OSU-June-Membership-Meeting.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings