### PR TITLE
Add confirmed CAT meeting end time

### DIFF
--- a/events/2026-06-22-OSU-CAT-Meeting.html
+++ b/events/2026-06-22-OSU-CAT-Meeting.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Join SEIU Local 083 for the OSU CAT Meeting on Zoom at 6 p.m. Pacific time on June 22, 2026.">
+    <meta name="description" content="Join Local 083’s Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time on June 22, 2026.">
     <meta name="author" content="SEIU Local 503 at OSU">
     <title>Event: OSU CAT Meeting - SEIU Local 503, OSU</title>
     <style>html{visibility:hidden;}html.tw-ready{visibility:visible;}</style>
@@ -69,13 +69,13 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.local083.org/events/2026-06-22-OSU-CAT-Meeting.html">
     <meta property="og:title" content="Event: OSU CAT Meeting - SEIU Local 503, OSU">
-    <meta property="og:description" content="Join SEIU Local 083 for the OSU CAT Meeting on Zoom at 6 p.m. Pacific time on June 22, 2026.">
+    <meta property="og:description" content="Join Local 083’s Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time on June 22, 2026.">
     <meta property="og:image" content="https://www.local083.org/images/card.webp">
     <meta property="og:site_name" content="SEIU Local 503 at Oregon State University">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://www.local083.org/events/2026-06-22-OSU-CAT-Meeting.html">
     <meta name="twitter:title" content="Event: OSU CAT Meeting - SEIU Local 503, OSU">
-    <meta name="twitter:description" content="Join SEIU Local 083 for the OSU CAT Meeting on Zoom at 6 p.m. Pacific time on June 22, 2026.">
+    <meta name="twitter:description" content="Join Local 083’s Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time on June 22, 2026.">
     <meta name="twitter:image" content="https://www.local083.org/images/card.webp">
     <script type="application/ld+json">
 {
@@ -102,7 +102,7 @@
       "@id": "https://www.local083.org/events/2026-06-22-OSU-CAT-Meeting.html#webpage",
       "url": "https://www.local083.org/events/2026-06-22-OSU-CAT-Meeting.html",
       "name": "Event: OSU CAT Meeting - SEIU Local 503, OSU",
-      "description": "Join SEIU Local 083 for the OSU CAT Meeting on Zoom at 6 p.m. Pacific time on June 22, 2026.",
+      "description": "Join Local 083’s Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time on June 22, 2026.",
       "isPartOf": {
         "@id": "https://www.local083.org#website"
       },
@@ -116,6 +116,7 @@
       "name": "OSU CAT Meeting",
       "description": "SEIU Local 083 Contract Action Team meeting on Zoom.",
       "startDate": "2026-06-22T18:00:00-07:00",
+      "endDate": "2026-06-22T19:00:00-07:00",
       "eventStatus": "https://schema.org/EventScheduled",
       "location": {
         "@type": "VirtualLocation",
@@ -170,7 +171,7 @@
         <div class="container mx-auto px-6 py-16 text-center">
             <p class="text-brand-purple font-bold mb-2">Monday, June 22, 2026</p>
             <h1 class="text-5xl font-bold">OSU CAT Meeting</h1>
-            <p class="mt-4 text-lg text-text-secondary max-w-3xl mx-auto">Join SEIU Local 083's Contract Action Team meeting on Zoom at 6 p.m. Pacific time.</p>
+            <p class="mt-4 text-lg text-text-secondary max-w-3xl mx-auto">Join our Local 083 Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time.</p>
         </div>
     </section>
 
@@ -179,7 +180,7 @@
             <div class="lg:col-span-2 bg-white p-8 md:p-12 rounded-xl border border-border-color">
                 <h2 class="text-3xl font-bold mb-6">About this Event</h2>
                 <div class="prose max-w-none text-text-secondary text-lg leading-relaxed space-y-6">
-                    <p>Please join SEIU Local 083 for the OSU Contract Action Team meeting on Monday, June 22, 2026, at 6:00 PM Pacific time.</p>
+                    <p>Please join our Local 083 Contract Action Team meeting from 6 to 7 p.m. Pacific time Monday, June 22, 2026.</p>
                     <p>CAT meetings are where members coordinate outreach, share updates with coworkers, and help move union action across worksites. Use the Zoom link below to join.</p>
                 </div>
             </div>
@@ -190,7 +191,7 @@
                     <div class="space-y-5 text-lg">
                         <div>
                             <h4 class="font-bold">Date & Time</h4>
-                            <p class="text-text-secondary">Monday, June 22, 2026<br>6:00 PM Pacific Time</p>
+                            <p class="text-text-secondary">Monday, June 22, 2026<br>6-7 p.m. Pacific time</p>
                         </div>
                         <div>
                             <h4 class="font-bold">Location</h4>

--- a/events/events.json
+++ b/events/events.json
@@ -64,9 +64,9 @@
   },
   {
     "date": "2026-06-22",
-    "time": "6:00 PM PT",
+    "time": "6:00 PM - 7:00 PM PT",
     "title": "OSU CAT Meeting",
-    "description": "Join SEIU Local 083 for the OSU Contract Action Team meeting on Zoom at 6 p.m. Pacific time.",
+    "description": "Join our Local 083 Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time.",
     "type": "Zoom Meeting",
     "url": "/events/2026-06-22-OSU-CAT-Meeting.html",
     "featured": false,

--- a/events/rss.xml
+++ b/events/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Upcoming events from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:29 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/events/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>CAT Meeting</title>
@@ -403,7 +403,7 @@
       <title>OSU CAT Meeting</title>
       <link>https://www.local083.org/events/2026-06-22-OSU-CAT-Meeting.html</link>
       <guid isPermaLink="false">event:2026-06-22:OSU CAT Meeting</guid>
-      <description>Join SEIU Local 083 for the OSU Contract Action Team meeting on Zoom at 6 p.m. Pacific time. | Date: 2026-06-22 | Time: 6:00 PM PT | Location: Online via Zoom</description>
+      <description>Join our Local 083 Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time. | Date: 2026-06-22 | Time: 6:00 PM - 7:00 PM PT | Location: Online via Zoom</description>
       <pubDate>Mon, 22 Jun 2026 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Combined news and event updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:29 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Event] CAT Meeting</title>
@@ -63,7 +63,7 @@
       <title>[Event] OSU CAT Meeting</title>
       <link>https://www.local083.org/events/2026-06-22-OSU-CAT-Meeting.html</link>
       <guid isPermaLink="false">event:2026-06-22:OSU CAT Meeting:combined</guid>
-      <description>Join SEIU Local 083 for the OSU Contract Action Team meeting on Zoom at 6 p.m. Pacific time. | Date: 2026-06-22 | Time: 6:00 PM PT | Location: Online via Zoom</description>
+      <description>Join our Local 083 Contract Action Team meeting on Zoom from 6 to 7 p.m. Pacific time. | Date: 2026-06-22 | Time: 6:00 PM - 7:00 PM PT | Location: Online via Zoom</description>
       <pubDate>Mon, 22 Jun 2026 00:00:00 GMT</pubDate>
       <category>Zoom Meeting</category>
     </item>

--- a/news/rss.xml
+++ b/news/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>News and updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:29 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/news/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Our union bargaining update: 0% COLAs and a 19-year step path</title>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `events/2026-06-22-OSU-CAT-Meeting.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings