### PR TITLE
Expand cost-of-living language on rally page

### DIFF
--- a/events/2026-06-30-Rally-at-McNary-Field.html
+++ b/events/2026-06-30-Rally-at-McNary-Field.html
@@ -180,7 +180,7 @@
             <div class="lg:col-span-2 bg-white p-8 md:p-12 rounded-xl border border-border-color">
                 <h2 class="text-3xl font-bold mb-6">About this Event</h2>
                 <div class="prose max-w-none text-text-secondary text-lg leading-relaxed space-y-6">
-                    <p>Management is offering no raises or COLA for four years. That is not a fair contract, and we need a strong turnout to show that members are organized, united, and ready to fight for better.</p>
+                    <p>Management is offering no raises and no cost-of-living adjustment for four years. That is not a fair contract, and we need a strong turnout to show that members are organized, united, and ready to fight for better.</p>
                     <p>Join coworkers on Tuesday, June 30, from noon to 1 p.m. at McNary Field. We will have food, lawn games, and a clear message: OSU workers deserve real raises and a fair contract.</p>
                     <ul class="list-disc pl-6 space-y-3">
                         <li>Sign up now so we can plan food, turnout, and outreach.</li>

--- a/events/events.json
+++ b/events/events.json
@@ -188,7 +188,7 @@
     "date": "2026-06-30",
     "time": "12:00 PM - 1:00 PM",
     "title": "Rally June 30 at McNary Field",
-    "description": "Join coworkers at McNary Field for food, lawn games, and a strong show of unity. Management is offering no raises or COLA for four years, and members are showing up for real raises and a fair contract.",
+    "description": "Join coworkers at McNary Field for food, lawn games, and a strong show of unity. Management is offering no raises and no cost-of-living adjustment for four years, and members are showing up for real raises and a fair contract.",
     "type": "Rally",
     "url": "/events/2026-06-30-Rally-at-McNary-Field.html",
     "featured": true,

--- a/events/rss.xml
+++ b/events/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Upcoming events from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:43 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/events/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>CAT Meeting</title>
@@ -419,7 +419,7 @@
       <title>Rally June 30 at McNary Field</title>
       <link>https://www.local083.org/events/2026-06-30-Rally-at-McNary-Field.html</link>
       <guid isPermaLink="false">event:2026-06-30:Rally June 30 at McNary Field</guid>
-      <description>Join coworkers at McNary Field for food, lawn games, and a strong show of unity. Management is offering no raises or COLA for four years, and members are showing up for real raises and a fair contract. | Date: 2026-06-30 | Time: 12:00 PM - 1:00 PM | Location: McNary Field</description>
+      <description>Join coworkers at McNary Field for food, lawn games, and a strong show of unity. Management is offering no raises and no cost-of-living adjustment for four years, and members are showing up for real raises and a fair contract. | Date: 2026-06-30 | Time: 12:00 PM - 1:00 PM | Location: McNary Field</description>
       <pubDate>Tue, 30 Jun 2026 00:00:00 GMT</pubDate>
       <category>Rally</category>
     </item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Combined news and event updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:43 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Event] CAT Meeting</title>
@@ -47,7 +47,7 @@
       <title>[Event] Rally June 30 at McNary Field</title>
       <link>https://www.local083.org/events/2026-06-30-Rally-at-McNary-Field.html</link>
       <guid isPermaLink="false">event:2026-06-30:Rally June 30 at McNary Field:combined</guid>
-      <description>Join coworkers at McNary Field for food, lawn games, and a strong show of unity. Management is offering no raises or COLA for four years, and members are showing up for real raises and a fair contract. | Date: 2026-06-30 | Time: 12:00 PM - 1:00 PM | Location: McNary Field</description>
+      <description>Join coworkers at McNary Field for food, lawn games, and a strong show of unity. Management is offering no raises and no cost-of-living adjustment for four years, and members are showing up for real raises and a fair contract. | Date: 2026-06-30 | Time: 12:00 PM - 1:00 PM | Location: McNary Field</description>
       <pubDate>Tue, 30 Jun 2026 00:00:00 GMT</pubDate>
       <category>Rally</category>
     </item>

--- a/news/rss.xml
+++ b/news/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>News and updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:43 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/news/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Our union bargaining update: 0% COLAs and a 19-year step path</title>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `events/2026-06-30-Rally-at-McNary-Field.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings