### PR TITLE
Fix rally wearable dimensions

### DIFF
--- a/marketing/flyiers/2026-03-31-rally-wearables.html
+++ b/marketing/flyiers/2026-03-31-rally-wearables.html
@@ -67,14 +67,14 @@
 
     <main id="main-content">
         <div class="print-stage-note no-print">
-            Print this sheet at 100% on letter paper. The circles are sized for 2.25 inch buttons or stickers, with one clean set of six slogans per page.
+            Print this sheet at 100% on letter paper. The circles are sized for 2.25-inch buttons or stickers, with one clean set of six slogans per page.
         </div>
 
         <section class="letter-sheet letter-sheet--buttons" aria-label="March 31 rally wearable sticker and button sheet">
             <header class="wearable-header">
                 <div>
                     <span class="wearable-eyebrow">March 31 rally wearables</span>
-                    <h1>Readable 2.25 inch buttons and stickers for Tuesday</h1>
+                    <h1>Readable 2.25-inch buttons and stickers for Tuesday</h1>
                     <p>Use these prompts to start quick conversations before the rally. Print one page at a time, cut the six circles, and keep the focus on short, high-contrast questions.</p>
                     <span class="wearable-note">Wear on Tuesday. RSVP stays at local083.org/rally.</span>
                 </div>
@@ -90,7 +90,7 @@
             </div>
 
             <footer class="wearable-footer">
-                <p><strong>Print tip:</strong> Use 100% scale and cut on the circle edge for 2.25 inch button stock.</p>
+                <p><strong>Print tip:</strong> Use 100% scale and cut on the circle edge for 2.25-inch button stock.</p>
                 <p><strong>Campaign target:</strong> 300 members at the MU Quad from noon to 1 p.m.</p>
             </footer>
         </section>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `marketing/flyiers/2026-03-31-rally-wearables.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings