### PR TITLE
Make steward flyer roster evergreen

### DIFF
--- a/marketing/flyiers/steward-flyer.html
+++ b/marketing/flyiers/steward-flyer.html
@@ -20,7 +20,7 @@
         </header>
 
         <section class="flyer-section">
-            <p class="lead">A steward is a coworker who volunteers to represent our union on the job. Stewards are your first point of contact when we need to enforce our contract.</p>
+            <p class="lead">A steward is a trained coworker who represents our union on the job. Contact our steward team when you need help enforcing our contract or protecting your rights at work.</p>
             <div class="info-box">
                 <p><strong>Weingarten Rights:</strong> You have the right to union representation in a meeting with management when you believe the meeting could lead to discipline. Clearly state that you want a steward present.</p>
             </div>
@@ -28,50 +28,17 @@
 
         <section class="flyer-section" style="padding-top: 0;">
             <div class="grid-3">
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">PB</div>
-                    <div class="steward-card-name">Patrick Breshears</div>
-                    <div class="role-label">Chief Steward</div>
+                <div class="flyer-card">
+                    <h3>Questions about our contract?</h3>
+                    <p>Email our steward team for help understanding your rights and working conditions.</p>
                 </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">RK</div>
-                    <div class="steward-card-name">Richard Keuneke</div>
-                    <div class="role-label">VP / Steward</div>
+                <div class="flyer-card">
+                    <h3>Called into a meeting?</h3>
+                    <p>Contact a steward before answering questions if the meeting could lead to discipline.</p>
                 </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">AG</div>
-                    <div class="steward-card-name">Anne Gross</div>
-                    <div class="role-label">Steward</div>
-                </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">JJ</div>
-                    <div class="steward-card-name">Jax SN Johnson</div>
-                    <div class="role-label">Steward</div>
-                </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">SC</div>
-                    <div class="steward-card-name">Susan Clark</div>
-                    <div class="role-label">Steward</div>
-                </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">HJ</div>
-                    <div class="steward-card-name">Hayden Jenner</div>
-                    <div class="role-label">Steward</div>
-                </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">RB</div>
-                    <div class="steward-card-name">Russ Born</div>
-                    <div class="role-label">Pres. / Steward</div>
-                </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">TJ</div>
-                    <div class="steward-card-name">Tracey Jastad</div>
-                    <div class="role-label">Steward</div>
-                </div>
-                <div class="flyer-card" style="text-align: center;">
-                    <div class="initial-badge">AS</div>
-                    <div class="steward-card-name">Andrew Struthers</div>
-                    <div class="role-label">Steward</div>
+                <div class="flyer-card">
+                    <h3>Facing a workplace issue?</h3>
+                    <p>Share a short timeline and relevant documents so a trained steward can follow up.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `marketing/flyiers/steward-flyer.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings