### PR TITLE
Correct hardship leave guidance copy

### DIFF
--- a/resources/hardship-leave.html
+++ b/resources/hardship-leave.html
@@ -186,7 +186,7 @@
                 <p>As a regular status SEIU-represented employee at Oregon State University, you have the right to access Hardship Leave if you meet the contractual criteria.</p>
                 <ul class="list-disc pl-5 space-y-3">
                     <li><strong>Eligibility:</strong> You can apply for Hardship Leave for your own temporary serious medical condition or that of a qualifying family member.</li>
-                    <li><strong>Concurrent Use:</strong> Hardship Leave is intended to be used alongside protections like the Family Medical Leave Act (FMLA), the Oregon Family Leave Act (OFLA), and Paid Leave Oregon to help bridge the gap and keep your family financially secure.</li>
+                    <li><strong>Concurrent Use:</strong> Hardship Leave is intended to be used alongside protections like the Family and Medical Leave Act (FMLA), the Oregon Family Leave Act (OFLA), and Paid Leave Oregon to help bridge the gap and keep your family financially secure.</li>
                     <li><strong>The Hardship Pool:</strong> Our contract ensures that if a recipient recovers and does not use all the leave donated to them, the remaining hours are transferred to a campus-wide pool. This pool acts as a reserve safety net for future members in need.</li>
                 </ul>
 
@@ -204,7 +204,7 @@
                 <p>To make a donation, fill out the Hardship Leave Donation form available through the OSU Human Resources Portal. Remember that donations are irrevocable, and your donated hours are credited at the recipient's current regular hourly rate of pay.</p>
 
                 <h2 class="text-3xl font-bold text-brand-purple-dark border-b border-border-color pb-2">Need Assistance?</h2>
-                <p>If management denies your application or you have questions about how Hardship Leave interacts with Paid Leave Oregon or FMLA, do not navigate it alone. Contact our union's Member Assistance Center at <a href="tel:+18445037348">1-844-503-7348</a> or connect with an OSU steward today at our <a href="/contact.html">Get Help Page</a>.</p>
+                <p>If management denies your application or you have questions about how Hardship Leave interacts with Paid Leave Oregon or FMLA, do not navigate it alone. Contact our union's Member Assistance Center at <a href="tel:+18445037348">1-844-503-7348</a> or email our OSU steward team at <a href="mailto:083stewards@seiu503.org">083stewards@seiu503.org</a>.</p>
             </div>
         </article>
     </main>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `resources/hardship-leave.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings