### PR TITLE
Reframe bowling slide as a past event

### DIFF
--- a/marketing/2025-10-23-Bowling-Slide.html
+++ b/marketing/2025-10-23-Bowling-Slide.html
@@ -3,7 +3,8 @@
 <head>
 <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SEIU 503 - Member & Family Bowling Night</title>
+    <meta name="description" content="Local 083 members and their families gathered Oct. 23, 2025, for bowling, food and solidarity at OSU.">
+    <title>Member and Family Bowling Night - SEIU Local 503, OSU</title>
     <style>html{visibility:hidden;}html.tw-ready{visibility:visible;}</style>
     <script src="https://cdn.tailwindcss.com" onload="document.documentElement.classList.add('tw-ready')"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -53,14 +54,14 @@
     <link rel="canonical" href="https://www.local083.org/marketing/2025-10-23-Bowling-Slide.html">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.local083.org/marketing/2025-10-23-Bowling-Slide.html">
-    <meta property="og:title" content="SEIU 503 - Member &amp; Family Bowling Night">
-    <meta property="og:description" content="">
+    <meta property="og:title" content="Member and Family Bowling Night - SEIU Local 503, OSU">
+    <meta property="og:description" content="Local 083 members and their families gathered Oct. 23, 2025, for bowling, food and solidarity at OSU.">
     <meta property="og:image" content="https://www.local083.org/images/card.webp">
     <meta property="og:site_name" content="SEIU Local 503 at Oregon State University">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://www.local083.org/marketing/2025-10-23-Bowling-Slide.html">
-    <meta name="twitter:title" content="SEIU 503 - Member &amp; Family Bowling Night">
-    <meta name="twitter:description" content="">
+    <meta name="twitter:title" content="Member and Family Bowling Night - SEIU Local 503, OSU">
+    <meta name="twitter:description" content="Local 083 members and their families gathered Oct. 23, 2025, for bowling, food and solidarity at OSU.">
     <meta name="twitter:image" content="https://www.local083.org/images/card.webp">
     <script type="application/ld+json">
 {
@@ -86,8 +87,8 @@
       "@type": "WebPage",
       "@id": "https://www.local083.org/marketing/2025-10-23-Bowling-Slide.html#webpage",
       "url": "https://www.local083.org/marketing/2025-10-23-Bowling-Slide.html",
-      "name": "SEIU 503 - Member & Family Bowling Night",
-      "description": "",
+      "name": "Member and Family Bowling Night - SEIU Local 503, OSU",
+      "description": "Local 083 members and their families gathered Oct. 23, 2025, for bowling, food and solidarity at OSU.",
       "isPartOf": {
         "@id": "https://www.local083.org#website"
       },
@@ -113,22 +114,22 @@
                 <!-- Header: SEIU 503 Logo -->
                 <header class="w-full">
                     <div class="bg-white text-[#4D2D72] font-black text-[2.5vw] md:text-[2vw] lg:text-[1.5vw] py-2 px-4 inline-block rounded-md shadow-lg">
-                        SEIU 083 | Oregon State University
+                        SEIU Local 503 | Local 083 at Oregon State University
                     </div>
                 </header>
 
                 <!-- Main Section: Event Title and Details -->
                 <main id="main-content" class="flex-grow flex flex-col justify-center items-center text-center">
                     <h1 class="text-[10vw] md:text-[8vw] lg:text-[7vw] font-black leading-none text-shadow tracking-tight">
-                        Member & Family<br>Bowling Night
+                        Member and Family<br>Bowling Night
                     </h1>
                     <p class="text-[3vw] md:text-[2.5vw] lg:text-[1.8vw] mt-4 max-w-4xl text-shadow font-light">
-                        Join us for a fun-filled evening of bowling, food, and solidarity!
+                        Our members and their families gathered for an evening of bowling, food and solidarity.<br><strong>Past event: Thursday, Oct. 23, 2025, from 6 to 8 p.m.<br>Lanes &amp; Games, Memorial Union basement</strong>
                     </p>
 
                     <!-- Highlight Box -->
                     <div class="bg-yellow-400 text-black font-bold text-[3.5vw] md:text-[2.8vw] lg:text-[2.2vw] py-3 px-8 mt-8 rounded-lg shadow-xl transform rotate-[-2deg]">
-                        Food, Lanes, & Shoes Provided!
+                        Food, lanes and shoes were provided.
                     </div>
                 </main>
 


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `marketing/2025-10-23-Bowling-Slide.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings