### PR TITLE
Fix kickoff meeting presentation copy

### DIFF
--- a/news/2026-01-09-kickoff.html
+++ b/news/2026-01-09-kickoff.html
@@ -274,7 +274,7 @@
                     <i class="fas fa-users text-4xl text-seiu-purple mb-4"></i>
                     <h3 class="text-2xl font-header font-bold text-gray-900 mb-2">We Need You in the Room</h3>
                     <p class="mb-6 text-gray-600 max-w-2xl mx-auto">
-                        We will talk about the bargaining platform and have a guest presention from our SEIU 503 President Jonny Earl at this next General Membership Meeting. <strong>Management notices how many are at these meetings.</strong> If we show up empty, they offer empty. If we show up united, they listen.
+                        At our next general membership meeting, we will discuss the bargaining platform and hear a guest presentation from SEIU Local 503 President Johnny Earl. <strong>Management notices how many are at these meetings.</strong> If we show up empty, they offer empty. If we show up united, they listen.
                     </p>
                     <a href="../events/2026-01-15-Membership-Meeting.html" class="inline-block bg-purple-800 text-white hover:bg-purple-800 text-lg font-bold py-3 px-8 rounded-full transition-all shadow-md hover:shadow-lg transform hover:-translate-y-1">
                         <i class="fas fa-calendar-check mr-2"></i> Count Me In: Jan 15


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `news/2026-01-09-kickoff.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings