### PR TITLE
Clarify economics update copy

### DIFF
--- a/events/rss.xml
+++ b/events/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Upcoming events from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:39 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/events/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>CAT Meeting</title>

--- a/feed.xml
+++ b/feed.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>Combined news and event updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:39 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/feed.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>[Event] CAT Meeting</title>
@@ -103,7 +103,7 @@
       <title>[News] Economics They Say / We Say</title>
       <link>https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html</link>
       <guid isPermaLink="false">https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html#news</guid>
-      <description>Management said it would provide economics proposals, but failed to bring them when expected. SEIU put our proposals forward for members to review and share.</description>
+      <description>Management did not provide its promised economics proposals when expected. Our bargaining team published our proposals for members to review and share.</description>
       <pubDate>Thu, 07 May 2026 00:00:00 GMT</pubDate>
       <category>Bargaining</category>
       <category>Economics</category>

--- a/news/2026-05-07-economics-they-say-we-say.html
+++ b/news/2026-05-07-economics-they-say-we-say.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Read SEIU Local 503's economics update, including what management has not provided and where to find our proposal flyer.">
+    <meta name="description" content="Read our economics update on management's delayed proposals and review what our bargaining team put forward.">
     <meta name="author" content="SEIU Local 503 at OSU">
     <title>Economics They Say / We Say | SEIU Local 503 OSU</title>
     <style>html{visibility:hidden;}html.tw-ready{visibility:visible;}</style>
@@ -97,13 +97,13 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html">
     <meta property="og:title" content="Economics They Say / We Say | SEIU Local 503 OSU">
-    <meta property="og:description" content="Read SEIU Local 503's economics update, including what management has not provided and where to find our proposal flyer.">
+    <meta property="og:description" content="Read our economics update on management's delayed proposals and review what our bargaining team put forward.">
     <meta property="og:image" content="https://www.local083.org/images/card.webp">
     <meta property="og:site_name" content="SEIU Local 503 at Oregon State University">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html">
     <meta name="twitter:title" content="Economics They Say / We Say | SEIU Local 503 OSU">
-    <meta name="twitter:description" content="Read SEIU Local 503's economics update, including what management has not provided and where to find our proposal flyer.">
+    <meta name="twitter:description" content="Read our economics update on management's delayed proposals and review what our bargaining team put forward.">
     <meta name="twitter:image" content="https://www.local083.org/images/card.webp">
     <script type="application/ld+json">
 {
@@ -130,7 +130,7 @@
       "@id": "https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html#webpage",
       "url": "https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html",
       "name": "Economics They Say / We Say | SEIU Local 503 OSU",
-      "description": "Read SEIU Local 503's economics update, including what management has not provided and where to find our proposal flyer.",
+      "description": "Read our economics update on management's delayed proposals and review what our bargaining team put forward.",
       "isPartOf": {
         "@id": "https://www.local083.org#website"
       },
@@ -188,7 +188,7 @@
                 <h1 class="mt-6 text-center text-4xl md:text-5xl font-bold">Economics They Say / We Say</h1>
                 <p class="mt-4 max-w-4xl mx-auto text-center text-lg text-text-secondary">Management said it would bring economics proposals, but did not provide them when expected. Our union put our proposals forward so members can see what we are fighting for.</p>
                 <div class="mt-6 flex flex-col items-center gap-2 text-center text-sm text-text-secondary">
-                    <p>Prepared by <span class="font-semibold">SEIU 503 Sublocal 083</span></p>
+                    <p>Prepared by <span class="font-semibold">SEIU Local 503, Local 083</span></p>
                     <p>Updated <time datetime="2026-05-07">May 7, 2026</time></p>
                 </div>
                 <div class="mt-8 flex flex-col sm:flex-row sm:items-center justify-center gap-4">
@@ -203,7 +203,7 @@
                 <div class="mb-8 rounded-xl border border-brand-purple/15 bg-brand-purple-light/35 p-6">
                     <h2 class="text-2xl font-bold">Source note</h2>
                     <div class="article-content mt-3 text-base text-text-secondary space-y-3">
-                        <p>This comparison uses our current contract in <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener">the SEIU 2022-2026 collective bargaining agreement</a>, which remains in effect through <strong>June 30, 2026</strong>.</p>
+                        <p>This comparison uses <a href="/resources/seiu_cba_2022-2026.pdf" target="_blank" rel="noopener">our 2022-2026 collective bargaining agreement</a>, which lists <strong>June 30, 2026</strong>, as its expiration date.</p>
                         <p>Management language is drawn from <a href="https://usse-oregon.org/opu-seiu-negotiations/updates/" target="_blank" rel="noopener">the USSE negotiations updates page</a>. That is the management-side site publishing summaries for the Oregon Public Universities bargaining team. This page uses its March 30 and 31 session summary from a page last updated <strong>April 7, 2026</strong>.</p>
                         <p>If this page and the contract PDF ever differ, the contract PDF is the source of truth. The <strong>Our union says</strong> and <strong>Why it matters</strong> sections below are our union's analysis.</p>
                     </div>
@@ -218,7 +218,7 @@
                         </div>
                         <div class="rounded-xl border border-brand-purple/20 bg-brand-purple-light/40 p-5">
                             <p class="font-mono text-xs uppercase tracking-[0.2em] text-brand-purple-dark">Our union says</p>
-                            <p class="mt-3">SEIU put our proposals out. Members deserve to see what we are fighting for on wages, benefits, and the economic issues that shape our lives at work and at home.</p>
+                            <p class="mt-3">Our bargaining team published our proposals. Members deserve to see what we are fighting for on wages, benefits and the economic issues that shape our lives at work and at home.</p>
                         </div>
                     </div>
                     <div class="article-content mt-5 text-base text-text-secondary">
@@ -386,7 +386,7 @@
                         <div class="mt-6 grid lg:grid-cols-2 gap-6">
                             <div class="rounded-2xl border border-border-color bg-white p-6">
                                 <p class="font-mono text-xs uppercase tracking-[0.2em] text-text-secondary">- Current contract</p>
-                                <p class="mt-3 text-text-secondary">Article 57 says required uniforms or protective devices must be furnished or paid for by the university. It also provides rain gear for employees who as a regular and substantial part of their jobs work outside in inclement weather.</p>
+                                <p class="mt-3 text-text-secondary">Article 57 says required uniforms or protective devices must be furnished or paid for by the university. It also provides rain gear for employees who, as a regular and substantial part of their jobs, work outside in inclement weather.</p>
                                 <p class="mt-4 text-sm text-text-secondary">Source: our contract, Article 57, Sections 1 and 4.</p>
                             </div>
                             <div class="rounded-2xl border border-brand-purple/20 bg-white p-6">

--- a/news/news.json
+++ b/news/news.json
@@ -41,7 +41,7 @@
   },
   {
     "title": "Economics They Say / We Say",
-    "description": "Management said it would provide economics proposals, but failed to bring them when expected. SEIU put our proposals forward for members to review and share.",
+    "description": "Management did not provide its promised economics proposals when expected. Our bargaining team published our proposals for members to review and share.",
     "url": "/news/2026-05-07-economics-they-say-we-say.html",
     "image": "/images/card.webp",
     "alt": "SEIU Local 503 at Oregon State University card graphic",
@@ -50,7 +50,7 @@
       "Economics"
     ],
     "author": {
-      "name": "SEIU 503 Sublocal 083",
+      "name": "SEIU Local 503, Local 083",
       "title": "Union Leadership"
     },
     "publishedAt": "2026-05-07",

--- a/news/rss.xml
+++ b/news/rss.xml
@@ -5,7 +5,7 @@
     <link>https://www.local083.org</link>
     <description>News and updates from SEIU Local 503 at Oregon State University.</description>
     <language>en-us</language>
-    <lastBuildDate>Thu, 09 Jul 2026 22:15:35 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 10 Jul 2026 16:28:39 GMT</lastBuildDate>
     <atom:link href="https://www.local083.org/news/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Our union bargaining update: 0% COLAs and a 19-year step path</title>
@@ -31,7 +31,7 @@
       <title>Economics They Say / We Say</title>
       <link>https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html</link>
       <guid isPermaLink="true">https://www.local083.org/news/2026-05-07-economics-they-say-we-say.html</guid>
-      <description>Management said it would provide economics proposals, but failed to bring them when expected. SEIU put our proposals forward for members to review and share.</description>
+      <description>Management did not provide its promised economics proposals when expected. Our bargaining team published our proposals for members to review and share.</description>
       <pubDate>Thu, 07 May 2026 00:00:00 GMT</pubDate>
       <category>Bargaining</category>
       <category>Economics</category>


### PR DESCRIPTION
## What changed

This PR applies an isolated copy fix to `news/2026-05-07-economics-they-say-we-say.html`.

## Why

The site copy audit identified a clear branding, clarity, accuracy, accessibility, or metadata issue on this page.

## Member impact

Members receive clearer, more accurate, member-centered information.

## Root cause

The existing page copy was inconsistent, incomplete, or out of date.

## Validation

- Cross-branch copy audit passed
- `git diff --check` passed
- Strict site-quality scan reported 0 errors and 0 warnings