### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM XSS via javascript: URIs in current-action.js

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -75,3 +75,8 @@
 **Vulnerability:** Instances of target="_blank" were found missing the rel="noreferrer" attribute for external links, leaving the application susceptible to referral information leakage via the Referer header.
 **Learning:** Using target="_blank" for external cross-origin links without the rel="noreferrer" attribute causes the site to leak the referring page's URL to the external, potentially untrusted site.
 **Prevention:** Ensured rel="noopener noreferrer" is added to all user-facing external anchor tags that open in a new tab.
+
+## 2026-07-21 - [DOM-based XSS via javascript: URIs in current-action.js]
+**Vulnerability:** User-controlled URLs from the dynamic current action data payload (`cta.href`) were injected into `href` attributes via `setAttribute` without sanitizing the URL scheme in `js/current-action.js`.
+**Learning:** External data payloads (even when originating from internal CMS sources) can contain `javascript:` URIs. Using standard HTML escaping or default string manipulation (`safeText`) does not prevent execution of these URIs when injected into `href` attributes. Client-side rendering functions must implement protocol sanitization.
+**Prevention:** Ensured a robust `sanitizeUrl` function is defined and applied to all `cta.href` insertions to block `javascript:` and `data:` schemes before they are set as `href` attributes.

--- a/js/current-action.js
+++ b/js/current-action.js
@@ -3,6 +3,13 @@
 
     const safeText = (value) => String(value || '');
 
+    const sanitizeUrl = (url) => {
+        const str = String(url || '').trim();
+        const lower = str.toLowerCase();
+        if (lower.startsWith('javascript:') || lower.startsWith('data:')) return '#';
+        return str;
+    };
+
     const isVisible = (action, now = new Date()) => {
         const visibility = action && action.visibility;
         if (!visibility) return true;
@@ -95,7 +102,7 @@
 
             element.classList.remove('hidden');
             element.textContent = safeText(cta.label);
-            element.setAttribute('href', safeText(cta.href || '#'));
+            element.setAttribute('href', sanitizeUrl(safeText(cta.href || '#')));
             applyAnalytics(element, cta);
 
             if (cta.emailAction) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-controlled URLs from the dynamic current action data payload (`cta.href`) were injected into `href` attributes via `setAttribute` without sanitizing the URL scheme in `js/current-action.js`.
🎯 Impact: Attackers could inject `javascript:` URIs via the CMS, executing arbitrary JavaScript in the browser when a user clicks the affected CTA button.
🔧 Fix: Added a `sanitizeUrl` function to `js/current-action.js` to block `javascript:` and `data:` schemes, and applied it to `cta.href` before setting the `href` attribute. Updated the Sentinel journal.
✅ Verification: Tested locally using `pytest tests/` and `python3 scripts/site_quality_check.py --strict-placeholders`. Checked out the changes in `js/current-action.js` and confirmed they do not break existing functionality while blocking malicious URIs.

---
*PR created automatically by Jules for task [15310783087246809454](https://jules.google.com/task/15310783087246809454) started by @jaxsnjohnson*