### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM-based XSS via javascript URIs in current action payload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -75,3 +75,8 @@
 **Vulnerability:** Instances of target="_blank" were found missing the rel="noreferrer" attribute for external links, leaving the application susceptible to referral information leakage via the Referer header.
 **Learning:** Using target="_blank" for external cross-origin links without the rel="noreferrer" attribute causes the site to leak the referring page's URL to the external, potentially untrusted site.
 **Prevention:** Ensured rel="noopener noreferrer" is added to all user-facing external anchor tags that open in a new tab.
+
+## 2026-07-13 - [DOM-based XSS via javascript: URIs in Current Action payload]
+**Vulnerability:** User-controlled URLs (`cta.href`) derived from the `current-action.json` payload were injected directly into `href` attributes in `js/current-action.js` without any scheme sanitization, posing a risk of executing `javascript:` or `data:` URIs.
+**Learning:** External data payloads (even when originating from first-party JSON sources like `current-action.json`) should never be blindly trusted when creating dynamic DOM elements, especially when setting attributes like `href`. The earlier implementation of `window.Sentinel.sanitizeUrl()` needed to be applied consistently, even in non-template contexts like `setAttribute`.
+**Prevention:** Ensured the `sanitizeUrl` helper was defined locally in `js/current-action.js` (falling back to `window.Sentinel.sanitizeUrl` if available) and explicitly applied it to any `href` values dynamically assigned via `setAttribute()`.

--- a/js/current-action.js
+++ b/js/current-action.js
@@ -3,6 +3,19 @@
 
     const safeText = (value) => String(value || '');
 
+    const sanitizeUrl = (url) => {
+        if (window.Sentinel && typeof window.Sentinel.sanitizeUrl === 'function') {
+            return window.Sentinel.sanitizeUrl(url);
+        }
+        if (!url) return '#';
+        const str = String(url).trim();
+        const lower = str.toLowerCase();
+        if (lower.startsWith('javascript:') || lower.startsWith('data:')) {
+            return '#';
+        }
+        return str;
+    };
+
     const isVisible = (action, now = new Date()) => {
         const visibility = action && action.visibility;
         if (!visibility) return true;
@@ -95,7 +108,7 @@
 
             element.classList.remove('hidden');
             element.textContent = safeText(cta.label);
-            element.setAttribute('href', safeText(cta.href || '#'));
+            element.setAttribute('href', sanitizeUrl(cta.href || '#'));
             applyAnalytics(element, cta);
 
             if (cta.emailAction) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** User-controlled URLs (`cta.href`) coming from `current-action.json` were injected directly into the `href` attribute via `setAttribute` in `js/current-action.js` without scheme sanitization. This allowed `javascript:` or `data:` URIs to be executed.
🎯 **Impact:** Potential DOM-based Cross-Site Scripting (XSS) if the JSON payload contained malicious URLs, allowing attackers to execute JavaScript in the victim's browser context.
🔧 **Fix:** Introduced the `sanitizeUrl` helper into `js/current-action.js` and wrapped all dynamically set `href` attributes with it. This explicit check strips out `javascript:` and `data:` protocols, replacing them with `#`.
✅ **Verification:** Verified fix using `git diff`. Tested via `pytest tests/` and `python3 scripts/site_quality_check.py --strict-placeholders`.

Also logged findings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3903012205618710521](https://jules.google.com/task/3903012205618710521) started by @jaxsnjohnson*