### PR TITLE
🎨 Palette: Add actionable empty state to resource library

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,6 @@ Critical UX/accessibility learnings only.
 ## 2026-05-18 - [Add required indicators to critical inputs]
 **Learning:** Users and screen readers need clear indicators for mandatory fields, even outside of traditional <form> submissions (e.g., calculator inputs). Relying on implicit requirement degrades UX and accessibility.
 **Action:** Always add `required` and `aria-required="true"` attributes to essential <input> elements, and pair them with a visual indicator (like a red * with `aria-hidden="true"`) in the associated <label>.
+## 2026-07-14 - [Add clear button to empty states]
+**Learning:** When dynamically generating empty UI states for lists/searches (like the resource library), providing an actionable button (e.g., "Clear Search & Filters") directly inside the empty state allows users to quickly reset their context without needing to hunt for the original controls. Coupling this with `role="status"` ensures screen readers announce the empty result.
+**Action:** Always include a reset button and `role="status"` on dynamically rendered empty states for filtered lists to improve recovery and accessibility.

--- a/resources.html
+++ b/resources.html
@@ -341,7 +341,7 @@
                 <a class="resource-card" data-category="tools" data-search="salary pay wages report osu classified compensation" href="https://hr.oregonstate.edu/employees/administrators-supervisors/classification-compensation/salary-reports"><span class="resource-type">OSU information</span><h3>OSU Salary Reports</h3><p>Review salary information published by Oregon State University.</p><span class="card-link">Visit OSU →</span></a>
                 <a class="resource-card" data-category="tools" data-search="member benefits discounts seiu advantages" href="https://www.seiumb.com"><span class="resource-type">Member benefit</span><h3>SEIU Member Benefits</h3><p>Explore benefit and discount programs available to SEIU members.</p><span class="card-link">Explore benefits →</span></a>
                 <a class="resource-card" data-category="tools" data-search="costco membership bonus new member" href="/resources/costco.html"><span class="resource-type">Member benefit</span><h3>Costco Membership Bonus</h3><p>Information about the current membership promotion.</p><span class="card-link">See the details →</span></a>
-                <div class="empty-state" id="empty-state"><strong>No resources matched that search.</strong><br>Try a broader word or choose “All.”</div>
+                <div class="empty-state" id="empty-state" role="status"><strong>No resources matched that search.</strong><br>Try a broader word or choose “All.”<br><button id="reset-library-btn" class="filter-button" style="margin-top: 1rem;">Clear Search &amp; Filters</button></div>
             </div>
 
         </section>
@@ -444,6 +444,16 @@
             filters.forEach((item) => item.setAttribute('aria-pressed', String(item === button)));
             renderResources();
         }));
+
+        const resetLibraryBtn = document.getElementById('reset-library-btn');
+        if (resetLibraryBtn) {
+            resetLibraryBtn.addEventListener('click', () => {
+                librarySearch.value = '';
+                category = 'all';
+                filters.forEach((item) => item.setAttribute('aria-pressed', String(item.dataset.category === 'all')));
+                renderResources();
+            });
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
### 💡 What
Added an actionable "Clear Search & Filters" button and accessibility improvements to the empty state on the `resources.html` page.

### 🎯 Why
When users apply search filters that return zero results, they can get stuck in a "dead end." By providing a one-click way to reset their search and filters directly within the empty state, we significantly improve usability and error recovery. Additionally, adding `role="status"` ensures screen reader users are immediately informed when their search yields no results.

### 📸 Before/After
Before: The empty state displayed static text ("No resources matched that search...").
After: The empty state includes a styled `filter-button` that instantly resets all inputs and ARIA states when clicked, and the container correctly announces itself to assistive technology.

### ♿ Accessibility
- Added `role="status"` to `#empty-state` so the dynamic DOM change is read by screen readers.
- Ensured the reset button synchronously updates the `aria-pressed` state on all filter buttons to maintain semantic correctness.

---
*PR created automatically by Jules for task [4625630345461020593](https://jules.google.com/task/4625630345461020593) started by @jaxsnjohnson*