### PR TITLE
⚡ Bolt: Use string concatenation instead of regex for Date coercion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2024-05-18 - [Optimizing Loop Grouping]
 **Learning:** [Instantiating `new Date()` purely to extract year and month formatting during an Array reduce grouping loop causes heavy memory and CPU overhead. When the input date string is guaranteed to be zero-padded ISO-8601 (YYYY-MM-DD), the year and month components can be accurately extracted using simple substring operations instead of date parsing.]
 **Action:** [Use substring extraction (`date.substring(0, 7)`) to group dates directly, and defer date instantiation and `Intl.DateTimeFormat.format()` until rendering the final group header.]
+
+## 2024-05-18 - [Date Coercion Performance]
+**Learning:** [When coercing YYYY-MM-DD date strings into Date objects for local timezone formatting, using regex replacement (`new Date(dateString.replace(/-/g, '/'))`) introduces unnecessary regular expression engine overhead.]
+**Action:** [Use string concatenation (`new Date(dateString + 'T00:00:00')`) instead, which is significantly faster while achieving the same timezone-safe coercion.]

--- a/index.html
+++ b/index.html
@@ -1016,7 +1016,7 @@
                         year: 'numeric'
                     });
                     upcomingEvents.forEach(event => {
-                        event.parsedDate = new Date(event.date.replace(/-/g, '/'));
+                        event.parsedDate = new Date(event.date + 'T00:00:00');
                         event.formattedDateShort = dateShortFormatter.format(event.parsedDate);
                     });
 
@@ -1107,7 +1107,7 @@
                     // ⚡ Bolt: Format dates only for the sliced items to avoid expensive operations on hidden entries
                     const newsDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
                     sortedNews.forEach(item => {
-                        item.formattedPublishedAt = newsDateFormatter.format(new Date(item.publishedAt.replace(/-/g, '/')));
+                        item.formattedPublishedAt = newsDateFormatter.format(new Date(item.publishedAt + 'T00:00:00'));
                     });
 
                     if (sortedNews.length > 0) {


### PR DESCRIPTION
💡 What: Replaced `replace(/-/g, '/')` with string concatenation (`+ 'T00:00:00'`) when instantiating `new Date()` from YYYY-MM-DD strings in `index.html`.
🎯 Why: Regular expression matching inside tight processing blocks incurs unnecessary computational overhead, which can be avoided entirely since the desired output (bypassing UTC conversion in older engines by making it an ISO timestamp or forcing local time) can be achieved by simply appending `'T00:00:00'` to a standardized date string.
📊 Impact: Eliminates the Regex engine invocation during Date coercion, offering a minor but easily measurable performance improvement when parsing lists of events and news articles.
🔬 Measurement: Verify by running the site and ensuring dates in the "Upcoming Events" and "Latest News" sections still format correctly to the user's local timezone. Run `pytest tests/` and `site_quality_check.py` to confirm no regressions.

---
*PR created automatically by Jules for task [13962608028683404854](https://jules.google.com/task/13962608028683404854) started by @jaxsnjohnson*